### PR TITLE
Wire vision LLM panel detection into Kumiko pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,6 +142,7 @@ research/results/report.html
 research/vision-benchmark*/
 research/vision-benchmark*.jpg
 .vercel
+.panel_llm_cache/
 
 .DS_STORE
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ Given a chapter URL, the service:
 
 1. downloads matching PNG images from the chapter HTML;
 2. stores the original image URLs alongside the temporary downloads;
-3. calculates the panel layout using the bundled Kumiko implementation;
+3. calculates the panel layout using the bundled Kumiko implementation, with an
+   optional vision LLM fallback or replacement pass;
 4. caches the result under `jsons/<chapter_hash>/kumiko.json`; and
 5. deletes the temporary images and returns the Kumiko result to the caller.
 
@@ -96,6 +97,21 @@ Railway MySQL reference-variable mappings and the required `feedback` table
 schema are documented in [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md).
 
 Do not commit `.env`; it is ignored by Git.
+
+Optional vision-LLM panel detection is controlled at runtime:
+
+```text
+PANEL_LLM_MODE=off|fallback|always
+PANEL_LLM_MODEL_CHOICE=quality|cheap
+PANEL_LLM_MODEL=openai/gpt-5.5
+PANEL_LLM_CHEAP_MODEL=qwen/qwen3-vl-30b-a3b-thinking
+OPENROUTER_API_KEY=...
+```
+
+`off` is the default. `fallback` uses local detector-confidence heuristics before
+calling the LLM. `always` runs the configured LLM for every page. LLM results are
+cached by image hash and model under `.panel_llm_cache/` unless
+`PANEL_LLM_CACHE_DIR` is set.
 
 ## Current source compatibility
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -17,7 +17,7 @@ FastAPI (app.py)
   |     `-- write images/<hash>/ and img_dict.json
   |
   +-- Kumiko.parse_dir()
-  |     `-- reading layout -> kumiko.json
+  |     `-- local panel detection, optional vision LLM pass -> kumiko.json
   |
   `-- return result or chapter hash
 ```
@@ -31,7 +31,7 @@ background job, object storage, or shared cache in the checked-in application.
 | --- | --- | --- |
 | `app.py` | FastAPI application, routing, orchestration, CORS, logging | Active |
 | `utils.py` | HTML/image download, file discovery, JSON and image helpers | Active |
-| `kumikolib.py`, `kcore/` | Bundled Kumiko page-layout algorithm | Active |
+| `kumikolib.py`, `kcore/` | Bundled Kumiko page-layout algorithm and optional vision LLM detector | Active |
 | `feedback_service.py` | MySQL connection and feedback insert | Active for feedback endpoint |
 | `output.json` | Historical example output | Sample only |
 | `test_utils.py` | Downloader URL and file-discovery unit tests | Active |
@@ -64,7 +64,7 @@ the source image URL and a list of panel rectangles/paths for every page.
 
 ## Algorithm
 
-Kumiko is the single production layout algorithm and is configured for
+Kumiko is the default production layout algorithm and is configured for
 right-to-left reading:
 
 ```python
@@ -76,9 +76,39 @@ right-to-left reading:
 }
 ```
 
+`PANEL_LLM_MODE` can enable the vision-LLM detector described in
+`docs/VISION_LLM_PANEL_DETECTION_DECISION.md`:
+
+- `off` keeps local detection only. This is the default.
+- `fallback` runs local detection first and calls the configured vision LLM only
+  when detector-confidence heuristics flag the page as risky.
+- `always` uses the configured vision LLM for every page after the local pass.
+
+The production helper asks for strict percentage bounding boxes, validates and
+clamps tiny provider overflows, sorts panels in reading order, and caches results
+by image hash plus model slug under `.panel_llm_cache/` unless
+`PANEL_LLM_CACHE_DIR` overrides it. It records model, latency, usage, request id,
+cache status, and confidence reasons in each page's `panelLlm` metadata when the
+LLM path is attempted or used. Provider failures fall back to local panels and
+store non-secret error metadata.
+
+Model and provider settings:
+
+```text
+PANEL_LLM_MODEL_CHOICE=quality|cheap
+PANEL_LLM_MODEL=openai/gpt-5.5
+PANEL_LLM_CHEAP_MODEL=qwen/qwen3-vl-30b-a3b-thinking
+PANEL_LLM_API_URL=https://openrouter.ai/api/v1/chat/completions
+PANEL_LLM_API_KEY_ENV=OPENROUTER_API_KEY
+PANEL_LLM_TIMEOUT=120
+PANEL_LLM_CACHE_DIR=.panel_llm_cache
+```
+
 ## External dependencies
 
 - Chapter websites and their image CDNs
+- OpenRouter or another OpenAI-compatible vision gateway when
+  `PANEL_LLM_MODE` is `fallback` or `always`
 - MySQL, but only for `POST /v2/feedback`
 - OnePanel web clients allowed by the hard-coded CORS list
 

--- a/kcore/vision_llm.py
+++ b/kcore/vision_llm.py
@@ -1,0 +1,332 @@
+import base64
+import hashlib
+import json
+import os
+import re
+import time
+from io import BytesIO
+from pathlib import Path
+
+import requests
+import numpy as np
+from PIL import Image
+
+
+OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions"
+DEFAULT_QUALITY_MODEL = "openai/gpt-5.5"
+DEFAULT_CHEAP_MODEL = "qwen/qwen3-vl-30b-a3b-thinking"
+
+PANEL_SCHEMA = {
+	"type": "object",
+	"additionalProperties": False,
+	"properties": {
+		"panels": {
+			"type": "array",
+			"items": {
+				"type": "object",
+				"additionalProperties": False,
+				"properties": {
+					"x": {"type": "number", "minimum": 0, "maximum": 100},
+					"y": {"type": "number", "minimum": 0, "maximum": 100},
+					"w": {"type": "number", "exclusiveMinimum": 0, "maximum": 100},
+					"h": {"type": "number", "exclusiveMinimum": 0, "maximum": 100},
+				},
+				"required": ["x", "y", "w", "h"],
+			},
+		},
+	},
+	"required": ["panels"],
+}
+
+PROMPT = """Find every manga/comic story panel in this page.
+Return each panel's tight axis-aligned bounding box as percentages of the full
+image: x and y are the top-left corner, w and h are width and height.
+Include borderless and full-bleed panels. Exclude speech balloons, captions,
+characters, inset decorations, and the whole page unless it is genuinely one
+panel. Do not merge panels separated by a gutter or border."""
+
+
+class VisionPanelError(RuntimeError):
+	def __init__(self, message, debug=None):
+		super().__init__(message)
+		self.debug = debug or {}
+
+
+def panel_llm_config(options=None):
+	options = options or {}
+	quality_model = options.get("panel_llm_model") or os.getenv(
+		"PANEL_LLM_MODEL", DEFAULT_QUALITY_MODEL,
+	)
+	cheap_model = options.get("panel_llm_cheap_model") or os.getenv(
+		"PANEL_LLM_CHEAP_MODEL", DEFAULT_CHEAP_MODEL,
+	)
+	model_choice = (
+		options.get("panel_llm_model_choice")
+		or os.getenv("PANEL_LLM_MODEL_CHOICE", "quality")
+	).lower()
+	model = cheap_model if model_choice == "cheap" else quality_model
+	return {
+		"mode": (
+			options.get("panel_llm_mode")
+			or os.getenv("PANEL_LLM_MODE", "off")
+		).lower(),
+		"model": model,
+		"quality_model": quality_model,
+		"cheap_model": cheap_model,
+		"model_choice": model_choice,
+		"api_url": options.get("panel_llm_api_url") or os.getenv(
+			"PANEL_LLM_API_URL", OPENROUTER_URL,
+		),
+		"api_key_env": options.get("panel_llm_api_key_env") or os.getenv(
+			"PANEL_LLM_API_KEY_ENV", "OPENROUTER_API_KEY",
+		),
+		"timeout": int(options.get("panel_llm_timeout") or os.getenv(
+			"PANEL_LLM_TIMEOUT", "120",
+		)),
+		"cache_dir": Path(options.get("panel_llm_cache_dir") or os.getenv(
+			"PANEL_LLM_CACHE_DIR", ".panel_llm_cache",
+		)),
+	}
+
+
+def image_sha256(path):
+	digest = hashlib.sha256()
+	with open(path, "rb") as handle:
+		for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+			digest.update(chunk)
+	return digest.hexdigest()
+
+
+def cache_path(path, model, cache_dir):
+	safe_model = re.sub(r"[^A-Za-z0-9_.-]+", "_", model)
+	return cache_dir / f"{image_sha256(path)}-{safe_model}.json"
+
+
+def image_data_url(path, max_dimension=1600):
+	with Image.open(path) as image:
+		image = image.convert("RGB")
+		image.thumbnail((max_dimension, max_dimension))
+		buffer = BytesIO()
+		image.save(buffer, format="JPEG", quality=90)
+	return "data:image/jpeg;base64," + base64.b64encode(buffer.getvalue()).decode()
+
+
+def validate_panels(payload):
+	panels = payload.get("panels") if isinstance(payload, dict) else None
+	if not isinstance(panels, list):
+		raise ValueError("response does not contain a panels array")
+	normalized = []
+	for panel in panels:
+		if not isinstance(panel, dict):
+			raise ValueError("panel is not an object")
+		try:
+			x, y, width, height = (
+				float(panel[name]) for name in ("x", "y", "w", "h")
+			)
+		except (KeyError, TypeError, ValueError) as error:
+			raise ValueError("panel has invalid coordinates") from error
+		if x < 0 or y < 0 or x > 100 or y > 100 or width <= 0 or height <= 0:
+			raise ValueError(f"panel lies outside the image: {panel}")
+		if x + width > 100.5 or y + height > 100.5:
+			raise ValueError(f"panel lies outside the image: {panel}")
+		normalized.append({
+			"x": max(0.0, min(100.0, x)),
+			"y": max(0.0, min(100.0, y)),
+			"w": max(0.0, min(100.0 - x, width)),
+			"h": max(0.0, min(100.0 - y, height)),
+		})
+	return normalized
+
+
+def normalize_coordinate_list(items, image_size):
+	width, height = image_size
+	normalized = []
+	for item in items:
+		if not isinstance(item, (list, tuple)) or len(item) != 4:
+			raise ValueError("panel coordinate list must contain four numbers")
+		try:
+			a, b, c, d = (float(value) for value in item)
+		except (TypeError, ValueError) as error:
+			raise ValueError("panel coordinate list has invalid numbers") from error
+		if max(a, b, c, d) <= 100.5:
+			normalized.append({"x": a, "y": b, "w": c, "h": d})
+		elif c > a and d > b and c <= width * 1.05 and d <= height * 1.05:
+			normalized.append({
+				"x": a * 100 / width,
+				"y": b * 100 / height,
+				"w": (c - a) * 100 / width,
+				"h": (d - b) * 100 / height,
+			})
+		else:
+			normalized.append({
+				"x": a * 100 / width,
+				"y": b * 100 / height,
+				"w": c * 100 / width,
+				"h": d * 100 / height,
+			})
+	return validate_panels({"panels": normalized})
+
+
+def parse_panel_message(message, image_size):
+	try:
+		payload = json.loads(message)
+	except (TypeError, json.JSONDecodeError):
+		payload = None
+	if isinstance(payload, dict):
+		return validate_panels(payload)
+	if isinstance(payload, list):
+		return normalize_coordinate_list(payload, image_size)
+	numbers = [
+		float(match) for match in
+		re.findall(r"-?\d+(?:\.\d+)?", message if isinstance(message, str) else "")
+	]
+	if numbers and len(numbers) % 4 == 0:
+		return normalize_coordinate_list(
+			[numbers[index:index + 4] for index in range(0, len(numbers), 4)],
+			image_size,
+		)
+	raise ValueError("model response is not valid panel JSON or coordinate list")
+
+
+def request_panels(path, config):
+	api_key = os.getenv(config["api_key_env"])
+	if not api_key:
+		raise VisionPanelError(f"set {config['api_key_env']} before using panel LLM")
+	body = {
+		"model": config["model"],
+		"temperature": 0,
+		"messages": [{
+			"role": "user",
+			"content": [
+				{"type": "text", "text": PROMPT},
+				{"type": "image_url", "image_url": {"url": image_data_url(path)}},
+			],
+		}],
+		"response_format": {
+			"type": "json_schema",
+			"json_schema": {
+				"name": "manga_panels",
+				"strict": True,
+				"schema": PANEL_SCHEMA,
+			},
+		},
+	}
+	started = time.monotonic()
+	response = requests.post(
+		config["api_url"],
+		headers={
+			"Authorization": f"Bearer {api_key}",
+			"Content-Type": "application/json",
+		},
+		json=body,
+		timeout=config["timeout"],
+	)
+	elapsed = time.monotonic() - started
+	debug = {
+		"latency_seconds": round(elapsed, 3),
+		"http_status": response.status_code,
+		"response_text": response.text[:4000],
+	}
+	try:
+		response.raise_for_status()
+	except requests.HTTPError as error:
+		raise VisionPanelError("provider request failed", debug) from error
+	try:
+		raw = response.json()
+	except ValueError as error:
+		raise VisionPanelError("provider response is not JSON", debug) from error
+	debug.update({
+		"model": raw.get("model", config["model"]) if isinstance(raw, dict) else config["model"],
+		"usage": raw.get("usage") if isinstance(raw, dict) else None,
+		"request_id": raw.get("id") if isinstance(raw, dict) else None,
+		"provider_error": raw.get("error") if isinstance(raw, dict) else None,
+	})
+	try:
+		message = raw["choices"][0]["message"]["content"]
+	except (KeyError, IndexError, TypeError) as error:
+		raise VisionPanelError("provider response does not contain choices", debug) from error
+	if isinstance(message, list):
+		message = "".join(part.get("text", "") for part in message)
+	debug["message"] = message[:4000] if isinstance(message, str) else repr(message)
+	try:
+		with Image.open(path) as image:
+			panels = parse_panel_message(message, image.size)
+	except ValueError as error:
+		raise VisionPanelError(str(error), debug) from error
+	return {
+		"panels": panels,
+		"latency_seconds": round(elapsed, 3),
+		"model": raw.get("model", config["model"]),
+		"usage": raw.get("usage"),
+		"request_id": raw.get("id"),
+		"cache_hit": False,
+	}
+
+
+def cached_request_panels(path, config):
+	result_path = cache_path(path, config["model"], config["cache_dir"])
+	if result_path.exists():
+		with result_path.open(encoding="utf-8") as handle:
+			record = json.load(handle)
+		record["cache_hit"] = True
+		return record
+	record = request_panels(path, config)
+	config["cache_dir"].mkdir(parents=True, exist_ok=True)
+	with result_path.open("w", encoding="utf-8") as handle:
+		json.dump(record, handle, indent=2)
+	return record
+
+
+def panels_overlap_fraction(first, second):
+	left = max(first["x"], second["x"])
+	top = max(first["y"], second["y"])
+	right = min(first["x"] + first["w"], second["x"] + second["w"])
+	bottom = min(first["y"] + first["h"], second["y"] + second["h"])
+	if right <= left or bottom <= top:
+		return 0.0
+	intersection = (right - left) * (bottom - top)
+	smaller = min(first["w"] * first["h"], second["w"] * second["h"])
+	return intersection / smaller if smaller else 0.0
+
+
+def estimate_detector_confidence(result, gray):
+	panels = [
+		{key: float(panel[key]) for key in ("x", "y", "w", "h")}
+		for panel in result.get("panels", [])
+	]
+	reasons = []
+	if len(panels) <= 1:
+		reasons.append("single_or_no_panel")
+	if len(panels) < 3 and edge_density(gray) > 0.08:
+		reasons.append("few_panels_on_dense_page")
+	if panels and max(panel["w"] * panel["h"] for panel in panels) > 6800:
+		if len(panels) > 1 or edge_density(gray) > 0.08:
+			reasons.append("huge_panel_on_complex_page")
+	if result.get("detector") == "adaptive-dark-gutter" and len(panels) < 3:
+		reasons.append("adaptive_dark_gutter_few_panels")
+	for index, panel in enumerate(panels):
+		for other in panels[index + 1:]:
+			if panels_overlap_fraction(panel, other) > 0.25:
+				reasons.append("heavy_panel_overlap")
+				break
+		if "heavy_panel_overlap" in reasons:
+			break
+	dark_fraction = result.get("backgroundDarkFraction")
+	if isinstance(dark_fraction, (int, float)) and 0.15 < dark_fraction < 0.75:
+		reasons.append("mixed_page_border_polarity")
+	return {
+		"low": bool(reasons),
+		"reasons": reasons,
+	}
+
+
+def edge_density(gray):
+	edges = Image.fromarray(gray).convert("L")
+	# Avoid adding another OpenCV dependency here; gray already came from OpenCV.
+	array = np.array(edges)
+	height, width = array.shape
+	if height < 2 or width < 2:
+		return 0.0
+	dx = abs(array[:, 1:].astype("int16") - array[:, :-1].astype("int16"))
+	dy = abs(array[1:, :].astype("int16") - array[:-1, :].astype("int16"))
+	return float(((dx > 40).mean() + (dy > 40).mean()) / 2)

--- a/kumikolib.py
+++ b/kumikolib.py
@@ -12,6 +12,12 @@ from functools import reduce
 from kcore.panel import Panel
 from kcore.debug import Debug
 from kcore.detection import border_dark_fraction, dark_gutter_panels, has_dark_gutters
+from kcore.vision_llm import (
+	VisionPanelError,
+	cached_request_panels,
+	estimate_detector_confidence,
+	panel_llm_config,
+)
 
 
 
@@ -54,6 +60,14 @@ class Kumiko:
 			self.options['min_panel_size_ratio'] = options['min_panel_size_ratio']
 
 		self.options['dark_page_strategy'] = options.get('dark_page_strategy', 'adaptive')
+		self.options['panel_llm_mode'] = options.get('panel_llm_mode')
+		self.options['panel_llm_model'] = options.get('panel_llm_model')
+		self.options['panel_llm_cheap_model'] = options.get('panel_llm_cheap_model')
+		self.options['panel_llm_model_choice'] = options.get('panel_llm_model_choice')
+		self.options['panel_llm_api_url'] = options.get('panel_llm_api_url')
+		self.options['panel_llm_api_key_env'] = options.get('panel_llm_api_key_env')
+		self.options['panel_llm_timeout'] = options.get('panel_llm_timeout')
+		self.options['panel_llm_cache_dir'] = options.get('panel_llm_cache_dir')
 	
 	
 	def parse_url_list(self,urls):
@@ -371,16 +385,82 @@ class Kumiko:
 					panel.to_xywh_path()
 					for panel in panel_objects
 				]
-				return infos
+				return self.apply_panel_llm(filename, infos)
 		
 		for bgcol in ['white','black']:
 			res = self.parse_image_with_bgcol(infos.copy(),filename,bgcol)
 			if len(res['panels']) > 1:
 				res['detector'] = 'legacy-contours'
-				return res
+				return self.apply_panel_llm(filename, res)
 		
 		res['detector'] = 'legacy-contours'
-		return res
+		return self.apply_panel_llm(filename, res)
+
+
+	def apply_panel_llm(self, filename, result):
+		config = panel_llm_config(self.options)
+		mode = config['mode']
+		if mode not in ['off', 'fallback', 'always']:
+			result['panelLlm'] = {
+				'mode': mode,
+				'error': 'invalid PANEL_LLM_MODE; expected off, fallback, or always',
+			}
+			return result
+		if mode == 'off':
+			return result
+
+		confidence = estimate_detector_confidence(result, self.gray)
+		result['detectorConfidence'] = confidence
+		if mode == 'fallback' and not confidence['low']:
+			return result
+
+		local_detector = result.get('detector')
+		try:
+			llm_result = cached_request_panels(filename, config)
+		except VisionPanelError as error:
+			result['panelLlm'] = {
+				'mode': mode,
+				'model': config['model'],
+				'localDetector': local_detector,
+				'confidenceReasons': confidence['reasons'],
+				'error': str(error),
+				'debug': {
+					key: value for key, value in error.debug.items()
+					if key not in ['response_text', 'message']
+				},
+			}
+			return result
+
+		result['panels'] = self.panel_percentages_to_output(llm_result['panels'])
+		result['detector'] = 'vision-llm'
+		result['panelLlm'] = {
+			'mode': mode,
+			'model': llm_result.get('model', config['model']),
+			'localDetector': local_detector,
+			'confidenceReasons': confidence['reasons'],
+			'latencySeconds': llm_result.get('latency_seconds'),
+			'usage': llm_result.get('usage'),
+			'requestId': llm_result.get('request_id'),
+			'cacheHit': llm_result.get('cache_hit', False),
+		}
+		return result
+
+
+	def panel_percentages_to_output(self, panels):
+		img_width, img_height = Panel.img_size
+		panel_objects = []
+		for panel in panels:
+			x = round(panel['x'] * img_width / 100)
+			y = round(panel['y'] * img_height / 100)
+			width = round(panel['w'] * img_width / 100)
+			height = round(panel['h'] * img_height / 100)
+			x = max(0, min(x, img_width - 1))
+			y = max(0, min(y, img_height - 1))
+			width = max(1, min(width, img_width - x))
+			height = max(1, min(height, img_height - y))
+			panel_objects.append(Panel([x, y, width, height]))
+		panel_objects.sort()
+		return [panel.to_xywh_path() for panel in panel_objects]
 	
 	
 	def parse_image_with_bgcol(self,infos,filename,bgcol):

--- a/test_vision_llm.py
+++ b/test_vision_llm.py
@@ -1,0 +1,132 @@
+import json
+
+import cv2 as cv
+import numpy as np
+
+from kcore.vision_llm import (
+	cache_path,
+	cached_request_panels,
+	estimate_detector_confidence,
+	panel_llm_config,
+	parse_panel_message,
+	validate_panels,
+)
+from kumikolib import Kumiko
+
+
+def test_validate_panels_clamps_tiny_provider_overflow():
+	assert validate_panels({
+		"panels": [{"x": 0, "y": 0, "w": 100.4, "h": 100.2}]
+	}) == [{"x": 0.0, "y": 0.0, "w": 100.0, "h": 100.0}]
+
+
+def test_panel_llm_config_selects_cheap_model():
+	config = panel_llm_config({
+		"panel_llm_model": "quality/model",
+		"panel_llm_cheap_model": "cheap/model",
+		"panel_llm_model_choice": "cheap",
+	})
+
+	assert config["model"] == "cheap/model"
+
+
+def test_parse_panel_message_accepts_pixel_xyxy_lists():
+	assert parse_panel_message("[[50, 160, 550, 960]]", (1000, 1600)) == [
+		{"x": 5.0, "y": 10.0, "w": 50.0, "h": 50.0}
+	]
+
+
+def test_confidence_flags_single_panel_dense_page():
+	gray = np.zeros((200, 200), dtype=np.uint8)
+	gray[:, ::8] = 255
+	result = {
+		"detector": "legacy-contours",
+		"backgroundDarkFraction": 0,
+		"panels": [{"x": 0, "y": 0, "w": 100, "h": 100}],
+	}
+
+	confidence = estimate_detector_confidence(result, gray)
+
+	assert confidence["low"]
+	assert "single_or_no_panel" in confidence["reasons"]
+	assert "few_panels_on_dense_page" in confidence["reasons"]
+
+
+def test_cached_request_panels_uses_existing_record(tmp_path, monkeypatch):
+	image_path = tmp_path / "page.png"
+	cv.imwrite(str(image_path), np.full((20, 20, 3), 255, dtype=np.uint8))
+	config = {
+		"model": "test/model",
+		"cache_dir": tmp_path / "cache",
+		"api_key_env": "OPENROUTER_API_KEY",
+		"api_url": "https://example.invalid",
+		"timeout": 1,
+	}
+	first = cached_request_panels
+
+	def fail_request(*args, **kwargs):
+		raise AssertionError("network should not be called for cache hit")
+
+	monkeypatch.setattr("kcore.vision_llm.request_panels", fail_request)
+	cache_file = cache_path(image_path, config["model"], config["cache_dir"])
+	config["cache_dir"].mkdir()
+	cache_file.write_text(
+		json.dumps({"panels": [{"x": 0, "y": 0, "w": 100, "h": 100}]}),
+		encoding="utf-8",
+	)
+
+	record = first(image_path, config)
+
+	assert record["cache_hit"] is True
+	assert record["panels"][0]["w"] == 100
+
+
+def test_kumiko_always_mode_replaces_local_panels(tmp_path, monkeypatch):
+	image_path = tmp_path / "page.png"
+	cv.imwrite(str(image_path), np.full((120, 80, 3), 255, dtype=np.uint8))
+
+	def fake_request(filename, config):
+		return {
+			"panels": [
+				{"x": 0, "y": 0, "w": 100, "h": 50},
+				{"x": 0, "y": 50, "w": 100, "h": 50},
+			],
+			"model": "test/model",
+			"cache_hit": False,
+		}
+
+	monkeypatch.setattr("kumikolib.cached_request_panels", fake_request)
+
+	result = Kumiko({
+		"panel_llm_mode": "always",
+		"panel_llm_model": "test/model",
+	}).parse_image(
+		str(image_path),
+		{"page.png": {"source_url": "page.png"}},
+	)
+
+	assert result["detector"] == "vision-llm"
+	assert result["panelLlm"]["localDetector"] == "legacy-contours"
+	assert len(result["panels"]) == 2
+
+
+def test_kumiko_fallback_mode_keeps_high_confidence_local_result(tmp_path, monkeypatch):
+	image_path = tmp_path / "page.png"
+	image = np.zeros((120, 80, 3), dtype=np.uint8)
+	image[10:50, 10:35] = 255
+	image[10:50, 45:70] = 255
+	image[70:110, 10:70] = 255
+	cv.imwrite(str(image_path), image)
+
+	def fail_request(*args, **kwargs):
+		raise AssertionError("high-confidence pages should stay local")
+
+	monkeypatch.setattr("kumikolib.cached_request_panels", fail_request)
+
+	result = Kumiko({"panel_llm_mode": "fallback"}).parse_image(
+		str(image_path),
+		{"page.png": {"source_url": "page.png"}},
+	)
+
+	assert result["detector"] in ["adaptive-dark-gutter", "legacy-contours"]
+	assert result["detectorConfidence"]["low"] is False


### PR DESCRIPTION
## Summary
- Adds `kcore/vision_llm.py`: calls a configurable OpenAI-compatible vision model (default OpenRouter) to detect panel bounding boxes, with per-image-hash+model caching, request/response validation, and structured error handling.
- Wires it into `Kumiko.parse_image` via a new `apply_panel_llm()` step, gated by `PANEL_LLM_MODE` (`off` / `fallback` / `always`), where `fallback` only calls the LLM when local detector-confidence heuristics flag the page as risky. Provider failures degrade gracefully to the local Kumiko result.
- Documents the new env vars (`PANEL_LLM_MODE`, `PANEL_LLM_MODEL_CHOICE`, `PANEL_LLM_MODEL`, `PANEL_LLM_CHEAP_MODEL`, `PANEL_LLM_API_URL`, `PANEL_LLM_API_KEY_ENV`, `PANEL_LLM_TIMEOUT`, `PANEL_LLM_CACHE_DIR`) in `README.md` and `docs/ARCHITECTURE.md`.
- Ignores the new `.panel_llm_cache/` directory.

Builds on the benchmark/decision doc from #9 (`docs/VISION_LLM_PANEL_DETECTION_DECISION.md`), turning it into a runnable production path.

## Test plan
- [x] `test_vision_llm.py` (7 tests) passes locally
- [ ] Manual smoke test with `PANEL_LLM_MODE=fallback` and a real `OPENROUTER_API_KEY` against a low-confidence page
- [ ] Confirm `.panel_llm_cache/` entries are created and reused on repeat requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)