### PR TITLE
Add freemium segmentation modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ Given a chapter URL, the service:
 
 1. downloads matching PNG images from the chapter HTML;
 2. stores the original image URLs alongside the temporary downloads;
-3. calculates the panel layout using the bundled Kumiko implementation, with an
-   optional vision LLM fallback or replacement pass;
+3. calculates the panel layout using the bundled Kumiko implementation, using
+   either the Standard local detector or the GPT-5.6 Layout vision-model pass;
 4. caches the result under `jsons/<chapter_hash>/kumiko.json`; and
 5. deletes the temporary images and returns the Kumiko result to the caller.
 
@@ -42,7 +42,7 @@ Interactive API documentation is available at
 
 | Method | Path | Purpose |
 | --- | --- | --- |
-| `GET` | `/` | Basic process check; returns `{"Hello":"World"}` |
+| `GET` | `/` | Basic process check; returns service status |
 | `POST` | `/v2/chapter` | Process a chapter and return its hash |
 | `GET` | `/v2/chapter/{chapter_hash}` | Read a cached Kumiko result |
 | `GET` | `/v2/billing/status` | Read the authenticated user's subscription |
@@ -54,9 +54,25 @@ Request body for the chapter POST:
 
 ```json
 {
-  "chapter_url": "https://example.com/chapter/123"
+  "chapter_url": "https://opchapters.com/chapter/123",
+  "segmentation_mode": "standard"
 }
 ```
+
+`mode` is optional for backward compatibility and defaults to `standard`. The
+only accepted values are `standard` and `gpt-5.6-layout`; provider names and
+model identifiers are not part of the browser-facing API.
+
+Creation and retrieval access:
+
+| Mode | Create | Retrieve |
+| --- | --- | --- |
+| `standard` | Anonymous or signed in; no subscription lookup | Public by unguessable chapter hash |
+| `gpt-5.6-layout` | Signed-in active Pro subscriber | Any signed-in account |
+
+Standard and GPT-5.6 Layout have different cache identities for the same
+normalized source URL. Standard retains the historical MD5 identity, and cached
+results without `metadata.json` are interpreted as public Standard results.
 
 Feedback body:
 
@@ -68,8 +84,9 @@ Feedback body:
 }
 ```
 
-Chapter and billing endpoints require a Clerk bearer token. Chapter creation and
-retrieval also require an active Stripe subscription. Configure:
+Billing and account endpoints require a Clerk bearer token. Chapter endpoints
+accept an optional bearer token and enforce the mode-specific rules above.
+Configure:
 
 ```text
 CLERK_ISSUER
@@ -98,20 +115,23 @@ schema are documented in [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md).
 
 Do not commit `.env`; it is ignored by Git.
 
-Optional vision-LLM panel detection is controlled at runtime:
+The provider model used by GPT-5.6 Layout is controlled only by the server
+environment:
 
 ```text
 PANEL_LLM_MODE=off|fallback|always
 PANEL_LLM_MODEL_CHOICE=quality|cheap
-PANEL_LLM_MODEL=openai/gpt-5.5
+PANEL_LLM_MODEL=<confirmed-quality-provider-model>
 PANEL_LLM_CHEAP_MODEL=qwen/qwen3-vl-30b-a3b-thinking
 OPENROUTER_API_KEY=...
 ```
 
-`off` is the default. `fallback` uses local detector-confidence heuristics before
-calling the LLM. `always` runs the configured LLM for every page. LLM results are
-cached by image hash and model under `.panel_llm_cache/` unless
-`PANEL_LLM_CACHE_DIR` is set.
+API `standard` forces the LLM mode off. API `gpt-5.6-layout` forces it to
+`always` and uses `PANEL_LLM_MODEL`; clients cannot override either mapping.
+The lower-level `fallback` and cheap-model settings remain available to internal
+tools, benchmarks, and legacy direct Kumiko use, but do not define additional
+API modes. LLM results are cached by image hash and model under
+`.panel_llm_cache/` unless `PANEL_LLM_CACHE_DIR` is set.
 
 ## Current source compatibility
 

--- a/app.py
+++ b/app.py
@@ -1,9 +1,11 @@
+from __future__ import annotations
+
 import logging
 import os, json
-import hashlib
 import shutil
 import threading
 from pathlib import Path
+from typing import Optional
 from urllib.parse import urlparse
 
 from logging.handlers import TimedRotatingFileHandler
@@ -18,12 +20,20 @@ from pydantic import BaseModel
 # project
 from utils import download_lmages, save_file
 from feedback_service import save_feedback
-from auth_service import require_user
+from auth_service import optional_user, require_user, sign_in_required
 from billing_service import (
     create_checkout_url,
     create_portal_url,
     get_subscription_state,
     require_active_subscription,
+)
+from chapter_contract import (
+    AccessPolicy,
+    SegmentationMode,
+    chapter_cache_key,
+    detector_options_for,
+    read_metadata,
+    write_metadata,
 )
 
 load_dotenv()
@@ -74,13 +84,6 @@ app.add_middleware(
 
 from kumikolib import Kumiko, page_sort_key
 
-k = Kumiko({
-	'debug': False,
-	'progress': False,
-	'rtl': True,
-	'min_panel_size_ratio': False
-})
-
 # create logger
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
@@ -108,6 +111,10 @@ logger.addHandler(fh)
 
 class Data(BaseModel):
     chapter_url: str
+    segmentation_mode: SegmentationMode = SegmentationMode.STANDARD
+
+    class Config:
+        extra = "forbid"
 
 
 def validate_chapter_url(chapter_url: str) -> str:
@@ -132,14 +139,12 @@ def read_root():
 def health():
     return {"status": "ok"}
 
-def process_chapter(chapter_url):
+def process_chapter(
+    chapter_url,
+    mode: SegmentationMode = SegmentationMode.STANDARD,
+):
     request_id = uuid4()
-    # strip date at end of url
-    chapter_url = chapter_url.split('?')[0]
-
-    # Encode the string to bytes
-    chapter_url_encoded = chapter_url.encode()
-    chapter_hash = hashlib.md5(chapter_url_encoded).hexdigest()
+    chapter_hash = chapter_cache_key(chapter_url, mode)
     logger.info(f"request_id: {request_id}, chapter hash {chapter_hash}")
 
     result_file = JSONS_DIR / chapter_hash / "kumiko.json"
@@ -157,7 +162,8 @@ def process_chapter(chapter_url):
 
         logger.info(f"{total} images downloaded")
 
-        info = k.parse_dir(str(image_path))
+        detector = Kumiko(detector_options_for(mode))
+        info = detector.parse_dir(str(image_path))
         if not info["pages"]:
             raise HTTPException(
                 status_code=422,
@@ -167,6 +173,8 @@ def process_chapter(chapter_url):
         foldername = JSONS_DIR / chapter_hash
         foldername.mkdir(parents=True, exist_ok=True)
 
+        write_metadata(foldername, mode)
+        # Write the result last: its presence is the cache-complete marker.
         save_file(info, str(foldername / "kumiko.json"))
 
         logger.info("panels extracted")
@@ -175,24 +183,50 @@ def process_chapter(chapter_url):
     finally:
         shutil.rmtree(image_path, ignore_errors=True)
 
+async def authorize_creation(
+    mode: SegmentationMode,
+    user_id: Optional[str],
+) -> None:
+    if mode is SegmentationMode.STANDARD:
+        return
+    if user_id is None:
+        raise sign_in_required("Sign in to use GPT-5.6 Layout.")
+    await run_in_threadpool(require_active_subscription, user_id)
+
+
+def authorize_retrieval(metadata: dict, user_id: Optional[str]) -> None:
+    if metadata["access_policy"] == AccessPolicy.AUTHENTICATED.value:
+        if user_id is None:
+            raise sign_in_required("Sign in to view this GPT-5.6 Layout chapter.")
+
+
 @app.post("/v2/chapter")
-async def post_chapter_v2(data: Data, user_id: str = Depends(require_user)):
+async def post_chapter_v2(
+    data: Data,
+    user_id: Optional[str] = Depends(optional_user),
+):
     logger.info("New Request V2")
 
-    await run_in_threadpool(require_active_subscription, user_id)
     chapter_url = validate_chapter_url(data.chapter_url)
-    result = await run_in_threadpool(run_extraction, process_chapter, chapter_url)
+    # Premium authorization deliberately happens before entering the extraction
+    # lock, downloading pages, or consulting detector configuration.
+    await authorize_creation(data.segmentation_mode, user_id)
+    result = await run_in_threadpool(
+        run_extraction,
+        process_chapter,
+        chapter_url,
+        data.segmentation_mode,
+    )
 
     return result
 
 @app.get("/v2/chapter/{chapter_hash}")
 async def get_chapter(
     chapter_hash: str,
-    user_id: str = Depends(require_user),
+    user_id: Optional[str] = Depends(optional_user),
 ):
     logger.info(f"New Get Request, chapter hash: {chapter_hash}")
 
-    await run_in_threadpool(require_active_subscription, user_id)
     result_file = JSONS_DIR / chapter_hash / "kumiko.json"
     if not result_file.exists():
         raise HTTPException(
@@ -200,6 +234,8 @@ async def get_chapter(
             detail="Item not found",
         )
 
+    metadata = read_metadata(result_file.parent)
+    authorize_retrieval(metadata, user_id)
     with result_file.open() as file:
         result = json.load(file)
 
@@ -228,11 +264,11 @@ async def billing_portal(user_id: str = Depends(require_user)):
     return {"url": url}
 
 
-def run_extraction(extractor, chapter_url):
+def run_extraction(extractor, chapter_url, *args):
     # Image processing is memory intensive and is not safe to run concurrently
     # in the initial single-instance deployment.
     with extraction_lock:
-        return extractor(chapter_url)
+        return extractor(chapter_url, *args)
 
 @app.post("/v2/feedback")
 def post_feedback(data: dict):

--- a/auth_service.py
+++ b/auth_service.py
@@ -6,6 +6,15 @@ import jwt
 from fastapi import Header, HTTPException
 from jwt import PyJWKClient
 
+SIGN_IN_REQUIRED = "sign_in_required"
+
+
+def sign_in_required(message: str = "Sign in to continue.") -> HTTPException:
+    return HTTPException(
+        status_code=401,
+        detail={"code": SIGN_IN_REQUIRED, "message": message},
+    )
+
 
 def _required_env(name: str) -> str:
     value = os.environ.get(name, "").strip()
@@ -38,9 +47,8 @@ def verify_session_token(token: str) -> str:
             },
         )
     except (jwt.PyJWTError, RuntimeError) as error:
-        raise HTTPException(
-            status_code=401,
-            detail="Your session is invalid or expired. Please sign in again.",
+        raise sign_in_required(
+            "Your session is invalid or expired. Please sign in again.",
         ) from error
 
     authorized_parties = {
@@ -49,18 +57,29 @@ def verify_session_token(token: str) -> str:
         if party.strip()
     }
     if authorized_parties and claims.get("azp") not in authorized_parties:
-        raise HTTPException(status_code=401, detail="Invalid session origin.")
+        raise sign_in_required("Invalid session origin.")
 
     if claims.get("sts") not in (None, "active"):
-        raise HTTPException(status_code=401, detail="Your session is not active.")
+        raise sign_in_required("Your session is not active.")
 
     return claims["sub"]
+
+
+def optional_user(
+    authorization: Optional[str] = Header(default=None),
+) -> Optional[str]:
+    if authorization is None:
+        return None
+    scheme, separator, token = (authorization or "").partition(" ")
+    if separator != " " or scheme.lower() != "bearer" or not token.strip():
+        raise sign_in_required()
+    return verify_session_token(token.strip())
 
 
 def require_user(
     authorization: Optional[str] = Header(default=None),
 ) -> str:
-    scheme, separator, token = (authorization or "").partition(" ")
-    if separator != " " or scheme.lower() != "bearer" or not token.strip():
-        raise HTTPException(status_code=401, detail="Sign in to continue.")
-    return verify_session_token(token.strip())
+    user_id = optional_user(authorization)
+    if user_id is None:
+        raise sign_in_required()
+    return user_id

--- a/billing_service.py
+++ b/billing_service.py
@@ -7,6 +7,7 @@ from fastapi import HTTPException
 
 
 ACTIVE_SUBSCRIPTION_STATUSES = {"active"}
+SUBSCRIPTION_REQUIRED = "subscription_required"
 
 
 @dataclass(frozen=True)
@@ -93,7 +94,10 @@ def require_active_subscription(clerk_user_id: str) -> None:
     if not get_subscription_state(clerk_user_id).active:
         raise HTTPException(
             status_code=402,
-            detail="An active OnePanel Pro subscription is required.",
+            detail={
+                "code": SUBSCRIPTION_REQUIRED,
+                "message": "An active OnePanel Pro subscription is required.",
+            },
         )
 
 

--- a/chapter_contract.py
+++ b/chapter_contract.py
@@ -1,0 +1,94 @@
+import hashlib
+import json
+import os
+from enum import Enum
+from pathlib import Path
+
+
+class SegmentationMode(str, Enum):
+    """Stable, browser-facing segmentation choices."""
+
+    STANDARD = "standard"
+    GPT_5_6_LAYOUT = "gpt-5.6-layout"
+
+
+class AccessPolicy(str, Enum):
+    PUBLIC = "public"
+    AUTHENTICATED = "authenticated"
+
+
+def normalize_source_url(source_url: str) -> str:
+    """Preserve the API's historical cache normalization behavior."""
+
+    return source_url.split("?", 1)[0]
+
+
+def chapter_cache_key(source_url: str, mode: SegmentationMode) -> str:
+    normalized_url = normalize_source_url(source_url)
+    if mode is SegmentationMode.STANDARD:
+        # Standard deliberately retains the legacy hash so existing links and
+        # cached results remain valid.
+        identity = normalized_url
+    else:
+        identity = f"{normalized_url}\n{mode.value}"
+    return hashlib.md5(identity.encode()).hexdigest()
+
+
+def access_policy_for(mode: SegmentationMode) -> AccessPolicy:
+    if mode is SegmentationMode.STANDARD:
+        return AccessPolicy.PUBLIC
+    return AccessPolicy.AUTHENTICATED
+
+
+def detector_options_for(mode: SegmentationMode) -> dict:
+    """Translate a product mode to server-owned detector configuration.
+
+    Provider model identifiers only come from server environment variables;
+    API callers cannot select or submit them.
+    """
+
+    options = {
+        "debug": False,
+        "progress": False,
+        "rtl": True,
+        "min_panel_size_ratio": False,
+        "panel_llm_mode": "off",
+    }
+    if mode is SegmentationMode.GPT_5_6_LAYOUT:
+        options["panel_llm_mode"] = "always"
+        configured_model = os.environ.get("PANEL_LLM_MODEL")
+        if configured_model:
+            options["panel_llm_model"] = configured_model
+    return options
+
+
+def metadata_for(mode: SegmentationMode) -> dict:
+    return {
+        "segmentation_mode": mode.value,
+        "access_policy": access_policy_for(mode).value,
+    }
+
+
+def write_metadata(result_directory: Path, mode: SegmentationMode) -> None:
+    with (result_directory / "metadata.json").open("w") as metadata_file:
+        json.dump(metadata_for(mode), metadata_file)
+
+
+def read_metadata(result_directory: Path) -> dict:
+    metadata_path = result_directory / "metadata.json"
+    if not metadata_path.exists():
+        # Results created before segmentation modes were introduced are
+        # Standard results and retain their public-link behavior.
+        return metadata_for(SegmentationMode.STANDARD)
+
+    with metadata_path.open() as metadata_file:
+        payload = json.load(metadata_file)
+    mode = SegmentationMode(payload["segmentation_mode"])
+    expected_policy = access_policy_for(mode)
+    policy = AccessPolicy(payload["access_policy"])
+    if policy is not expected_policy:
+        raise ValueError("chapter metadata has an invalid access policy")
+    return {
+        "segmentation_mode": mode.value,
+        "access_policy": policy.value,
+    }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -9,15 +9,16 @@ Client
   v
 FastAPI (app.py)
   |
-  +-- normalize URL and calculate MD5 chapter hash
+  +-- validate mode, authorize caller, and calculate mode-aware cache key
   |
   +-- utils.download_lmages()
   |     +-- fetch chapter HTML
   |     +-- select matching PNG/WebP <img> sources
   |     `-- write images/<hash>/ and img_dict.json
   |
-  +-- Kumiko.parse_dir()
-  |     `-- local panel detection, optional vision LLM pass -> kumiko.json
+  +-- construct per-request Kumiko detector
+  |     +-- standard -> local detector
+  |     `-- gpt-5.6-layout -> server-selected quality vision model
   |
   `-- return result or chapter hash
 ```
@@ -38,7 +39,7 @@ background job, object storage, or shared cache in the checked-in application.
 
 ## Data model
 
-For each normalized chapter URL:
+For each normalized chapter URL and segmentation mode:
 
 ```text
 images/<md5>/ (temporary during extraction)
@@ -47,6 +48,7 @@ images/<md5>/ (temporary during extraction)
 
 jsons/<md5>/
   kumiko.json
+  metadata.json
 ```
 
 Downloaded pages use zero-padded sequential filenames and carry a `page_index`
@@ -64,8 +66,18 @@ the source image URL and a list of panel rectangles/paths for every page.
 
 ## Algorithm
 
-Kumiko is the default production layout algorithm and is configured for
-right-to-left reading:
+Each request receives a fresh Kumiko instance configured for right-to-left
+reading. The complete download/detection/write operation remains protected by
+the process-wide extraction lock because image processing is memory intensive.
+The API maps product modes to detector options as follows:
+
+| API mode | Detector configuration |
+| --- | --- |
+| `standard` | Local Kumiko, `panel_llm_mode=off` |
+| `gpt-5.6-layout` | Kumiko plus `panel_llm_mode=always`, quality model from server `PANEL_LLM_MODEL` |
+
+The API accepts no provider model field. This keeps provider migration and the
+exact marketed GPT-5.6 model identifier under server control.
 
 ```python
 {
@@ -96,7 +108,7 @@ Model and provider settings:
 
 ```text
 PANEL_LLM_MODEL_CHOICE=quality|cheap
-PANEL_LLM_MODEL=openai/gpt-5.5
+PANEL_LLM_MODEL=<confirmed-quality-provider-model>
 PANEL_LLM_CHEAP_MODEL=qwen/qwen3-vl-30b-a3b-thinking
 PANEL_LLM_API_URL=https://openrouter.ai/api/v1/chat/completions
 PANEL_LLM_API_KEY_ENV=OPENROUTER_API_KEY

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -76,6 +76,16 @@ STRIPE_PRICE_ID
 FRONTEND_URL
 ```
 
+GPT-5.6 Layout additionally requires server-only vision provider settings:
+
+```text
+PANEL_LLM_MODEL=<confirmed provider model identifier>
+OPENROUTER_API_KEY=<secret>
+```
+
+Confirm the exact provider identifier in the deployment environment before
+enabling the frontend label. Never send it to or accept it from the browser.
+
 The Stripe Price must be active, recurring monthly, and exactly €4.99 EUR.
 Configure the Stripe Customer Portal in the same Stripe mode as the secret key.
 
@@ -120,6 +130,18 @@ logs.
 No Redis or queue variables are used by the active application.
 
 ## Deployment verification checklist
+
+Deploy the API before the freemium frontend. After the API deployment, verify in
+this order:
+
+1. Existing legacy chapter hashes still retrieve as public Standard chapters.
+2. Anonymous Standard creation and retrieval succeed.
+3. Standard and GPT-5.6 Layout produce distinct hashes for the same source URL.
+4. Signed-out and free-account premium creation is rejected before extraction.
+5. Active Pro premium creation uses the configured server quality model.
+6. A signed-in free account can retrieve a premium result, while an anonymous
+   caller cannot.
+7. Deploy the frontend, then verify upgrade and Checkout continuation flows.
 
 In Railway, record or verify:
 

--- a/test_access.py
+++ b/test_access.py
@@ -1,0 +1,130 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+from fastapi import HTTPException
+
+import app
+from chapter_contract import SegmentationMode, write_metadata
+
+
+class ChapterCreationAccessTest(unittest.IsolatedAsyncioTestCase):
+    async def test_standard_creation_access_matrix_skips_billing(self):
+        for user_id in (None, "free_user", "pro_user"):
+            with self.subTest(user_id=user_id), patch(
+                "app.require_active_subscription",
+            ) as require_subscription:
+                await app.authorize_creation(SegmentationMode.STANDARD, user_id)
+                require_subscription.assert_not_called()
+
+    async def test_anonymous_premium_creation_requires_sign_in(self):
+        with self.assertRaises(HTTPException) as raised:
+            await app.authorize_creation(
+                SegmentationMode.GPT_5_6_LAYOUT,
+                None,
+            )
+
+        self.assertEqual(raised.exception.status_code, 401)
+        self.assertEqual(raised.exception.detail["code"], "sign_in_required")
+
+    async def test_free_premium_creation_requires_subscription(self):
+        rejection = HTTPException(
+            status_code=402,
+            detail={
+                "code": "subscription_required",
+                "message": "Pro is required.",
+            },
+        )
+        with patch(
+            "app.run_in_threadpool",
+            new=AsyncMock(side_effect=rejection),
+        ):
+            with self.assertRaises(HTTPException) as raised:
+                await app.authorize_creation(
+                    SegmentationMode.GPT_5_6_LAYOUT,
+                    "free_user",
+                )
+
+        self.assertEqual(raised.exception.detail["code"], "subscription_required")
+
+    async def test_pro_premium_creation_is_allowed(self):
+        threadpool = AsyncMock(return_value=None)
+        with patch("app.run_in_threadpool", new=threadpool):
+            await app.authorize_creation(
+                SegmentationMode.GPT_5_6_LAYOUT,
+                "pro_user",
+            )
+
+        threadpool.assert_awaited_once_with(
+            app.require_active_subscription,
+            "pro_user",
+        )
+
+    async def test_rejected_premium_request_never_starts_extraction(self):
+        data = app.Data(
+            chapter_url="https://opchapters.com/chapter/one",
+            segmentation_mode=SegmentationMode.GPT_5_6_LAYOUT,
+        )
+        with patch(
+            "app.authorize_creation",
+            new=AsyncMock(side_effect=HTTPException(
+                status_code=402,
+                detail={
+                    "code": "subscription_required",
+                    "message": "Pro is required.",
+                },
+            )),
+        ), patch("app.run_extraction") as extraction:
+            with self.assertRaises(HTTPException):
+                await app.post_chapter_v2(data, "free_user")
+
+        extraction.assert_not_called()
+
+
+class ChapterRetrievalAccessTest(unittest.TestCase):
+    def test_standard_and_legacy_results_are_public(self):
+        for user_id in (None, "free_user", "pro_user"):
+            with self.subTest(user_id=user_id):
+                app.authorize_retrieval(
+                    {
+                        "segmentation_mode": "standard",
+                        "access_policy": "public",
+                    },
+                    user_id,
+                )
+
+    def test_premium_result_requires_account_but_not_subscription(self):
+        metadata = {
+            "segmentation_mode": "gpt-5.6-layout",
+            "access_policy": "authenticated",
+        }
+        with self.assertRaises(HTTPException) as raised:
+            app.authorize_retrieval(metadata, None)
+        self.assertEqual(raised.exception.detail["code"], "sign_in_required")
+
+        app.authorize_retrieval(metadata, "free_user")
+        app.authorize_retrieval(metadata, "pro_user")
+
+    def test_get_premium_result_does_not_consult_stripe(self):
+        with tempfile.TemporaryDirectory() as directory:
+            jsons_directory = Path(directory)
+            result_directory = jsons_directory / "premium_hash"
+            result_directory.mkdir()
+            (result_directory / "kumiko.json").write_text(
+                json.dumps({"pages": []}),
+            )
+            write_metadata(
+                result_directory,
+                SegmentationMode.GPT_5_6_LAYOUT,
+            )
+
+            with patch.object(app, "JSONS_DIR", jsons_directory), patch(
+                "app.require_active_subscription",
+            ) as require_subscription:
+                import asyncio
+                result = asyncio.run(app.get_chapter("premium_hash", "free_user"))
+
+            self.assertEqual(result, {"pages": []})
+            require_subscription.assert_not_called()

--- a/test_app_chapters.py
+++ b/test_app_chapters.py
@@ -1,0 +1,121 @@
+import asyncio
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from fastapi import HTTPException
+
+import app
+from chapter_contract import SegmentationMode, chapter_cache_key
+
+
+class ChapterProcessingTest(unittest.TestCase):
+    def setUp(self):
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        data_directory = Path(self.temporary_directory.name)
+        self.images_directory = data_directory / "images"
+        self.results_directory = data_directory / "jsons"
+        self.images_directory.mkdir()
+        self.results_directory.mkdir()
+        self.directories = patch.multiple(
+            app,
+            IMAGES_DIR=self.images_directory,
+            JSONS_DIR=self.results_directory,
+        )
+        self.directories.start()
+
+    def tearDown(self):
+        self.directories.stop()
+        self.temporary_directory.cleanup()
+
+    @patch("app.Kumiko")
+    @patch("app.download_lmages")
+    def test_processing_writes_result_and_reuses_mode_cache(
+        self,
+        download_images,
+        kumiko,
+    ):
+        source_url = "https://opchapters.com/chapter/1?tracking=yes"
+        detector = MagicMock()
+        detector.parse_dir.return_value = {
+            "pageCount": 1,
+            "pages": [{"filename": "1.png"}],
+        }
+        kumiko.return_value = detector
+        download_images.return_value = 1
+
+        first = app.process_chapter(source_url, SegmentationMode.STANDARD)
+        second = app.process_chapter(
+            "https://opchapters.com/chapter/1?tracking=other",
+            SegmentationMode.STANDARD,
+        )
+
+        self.assertEqual(first, second)
+        self.assertEqual(download_images.call_count, 1)
+        result_directory = self.results_directory / first["chapter_hash"]
+        self.assertTrue((result_directory / "kumiko.json").exists())
+        self.assertEqual(
+            json.loads((result_directory / "metadata.json").read_text()),
+            {
+                "segmentation_mode": "standard",
+                "access_policy": "public",
+            },
+        )
+
+    @patch("app.Kumiko")
+    @patch("app.download_lmages")
+    def test_premium_processing_uses_a_separate_cache(
+        self,
+        download_images,
+        kumiko,
+    ):
+        source_url = "https://opchapters.com/chapter/1"
+        detector = MagicMock()
+        detector.parse_dir.return_value = {
+            "pageCount": 1,
+            "pages": [{"filename": "1.png"}],
+        }
+        kumiko.return_value = detector
+        download_images.return_value = 1
+
+        standard = app.process_chapter(source_url, SegmentationMode.STANDARD)
+        premium = app.process_chapter(
+            source_url,
+            SegmentationMode.GPT_5_6_LAYOUT,
+        )
+
+        self.assertNotEqual(standard["chapter_hash"], premium["chapter_hash"])
+        self.assertEqual(download_images.call_count, 2)
+
+    def test_missing_result_is_not_found(self):
+        chapter_hash = chapter_cache_key(
+            "https://opchapters.com/missing",
+            SegmentationMode.STANDARD,
+        )
+        with patch("app.require_active_subscription"):
+            with self.assertRaises(HTTPException) as raised:
+                asyncio.run(app.get_chapter(chapter_hash, "user_123"))
+
+        self.assertEqual(raised.exception.status_code, 404)
+
+    def test_chapter_url_validation_accepts_supported_https_host(self):
+        source_url = "https://www.opchapters.com/chapter/1?date=latest"
+
+        self.assertEqual(app.validate_chapter_url(source_url), source_url)
+
+    def test_chapter_url_validation_rejects_other_origins(self):
+        for source_url in (
+            "http://opchapters.com/chapter/1",
+            "https://opchapters.com.attacker.example/chapter/1",
+            "https://example.com/chapter/1",
+        ):
+            with self.subTest(source_url=source_url):
+                with self.assertRaises(HTTPException) as raised:
+                    app.validate_chapter_url(source_url)
+                self.assertEqual(raised.exception.status_code, 400)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test_auth_service.py
+++ b/test_auth_service.py
@@ -79,6 +79,30 @@ class AuthServiceTest(unittest.TestCase):
         with self.assertRaises(HTTPException) as raised:
             auth_service.require_user(None)
         self.assertEqual(raised.exception.status_code, 401)
+        self.assertEqual(
+            raised.exception.detail["code"],
+            auth_service.SIGN_IN_REQUIRED,
+        )
+
+    def test_optional_user_permits_missing_token(self):
+        self.assertIsNone(auth_service.optional_user(None))
+
+    @patch("auth_service.verify_session_token", return_value="user_123")
+    def test_optional_user_validates_token_when_present(self, verify):
+        self.assertEqual(
+            auth_service.optional_user("Bearer session-token"),
+            "user_123",
+        )
+        verify.assert_called_once_with("session-token")
+
+    def test_optional_user_rejects_malformed_token(self):
+        with self.assertRaises(HTTPException) as raised:
+            auth_service.optional_user("Basic credentials")
+        self.assertEqual(raised.exception.status_code, 401)
+        self.assertEqual(
+            raised.exception.detail["code"],
+            auth_service.SIGN_IN_REQUIRED,
+        )
 
 
 if __name__ == "__main__":

--- a/test_billing_service.py
+++ b/test_billing_service.py
@@ -102,6 +102,22 @@ class BillingServiceTest(unittest.TestCase):
         self.assertTrue(state.active)
         self.assertEqual(state.status, "active")
 
+    @patch("billing_service.get_subscription_state")
+    def test_subscription_required_has_stable_error_code(self, state):
+        state.return_value = billing_service.SubscriptionState(
+            active=False,
+            status=None,
+        )
+
+        with self.assertRaises(HTTPException) as raised:
+            billing_service.require_active_subscription("user_123")
+
+        self.assertEqual(raised.exception.status_code, 402)
+        self.assertEqual(
+            raised.exception.detail["code"],
+            billing_service.SUBSCRIPTION_REQUIRED,
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test_chapter_contract.py
+++ b/test_chapter_contract.py
@@ -1,0 +1,134 @@
+import hashlib
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from pydantic import ValidationError
+
+from app import Data
+from chapter_contract import (
+    SegmentationMode,
+    chapter_cache_key,
+    detector_options_for,
+    read_metadata,
+    write_metadata,
+)
+
+
+class ChapterContractTest(unittest.TestCase):
+    def test_standard_is_the_backward_compatible_default(self):
+        request = Data(chapter_url="https://opchapters.com/chapter/1")
+
+        self.assertEqual(request.segmentation_mode, SegmentationMode.STANDARD)
+
+    def test_api_accepts_only_closed_product_mode_values(self):
+        premium = Data(
+            chapter_url="https://opchapters.com/chapter/1",
+            segmentation_mode="gpt-5.6-layout",
+        )
+        self.assertEqual(
+            premium.segmentation_mode,
+            SegmentationMode.GPT_5_6_LAYOUT,
+        )
+
+        with self.assertRaises(ValidationError):
+            Data(
+                chapter_url="https://opchapters.com/chapter/1",
+                segmentation_mode="openai/gpt-5.6",
+            )
+        with self.assertRaises(ValidationError):
+            Data(
+                chapter_url="https://opchapters.com/chapter/1",
+                segmentation_mode="future-mode",
+            )
+        with self.assertRaises(ValidationError):
+            Data(
+                chapter_url="https://opchapters.com/chapter/1",
+                provider_model="openai/gpt-5.6",
+            )
+
+    def test_standard_cache_identity_matches_legacy_url_normalization(self):
+        source_url = "https://opchapters.com/chapter/1?date=2026-01-01"
+        legacy_hash = hashlib.md5(
+            b"https://opchapters.com/chapter/1",
+        ).hexdigest()
+
+        self.assertEqual(
+            chapter_cache_key(source_url, SegmentationMode.STANDARD),
+            legacy_hash,
+        )
+        self.assertEqual(
+            chapter_cache_key(
+                "https://opchapters.com/chapter/1?different=true",
+                SegmentationMode.STANDARD,
+            ),
+            legacy_hash,
+        )
+
+    def test_modes_have_distinct_cache_identities(self):
+        source_url = "https://opchapters.com/chapter/1"
+
+        self.assertNotEqual(
+            chapter_cache_key(source_url, SegmentationMode.STANDARD),
+            chapter_cache_key(source_url, SegmentationMode.GPT_5_6_LAYOUT),
+        )
+
+    def test_provider_model_is_server_controlled(self):
+        with patch.dict(
+            os.environ,
+            {"PANEL_LLM_MODEL": "provider/server-selected-model"},
+        ):
+            standard = detector_options_for(SegmentationMode.STANDARD)
+            premium = detector_options_for(SegmentationMode.GPT_5_6_LAYOUT)
+
+        self.assertEqual(standard["panel_llm_mode"], "off")
+        self.assertNotIn("panel_llm_model", standard)
+        self.assertEqual(premium["panel_llm_mode"], "always")
+        self.assertEqual(
+            premium["panel_llm_model"],
+            "provider/server-selected-model",
+        )
+
+    def test_metadata_records_mode_and_access_policy(self):
+        with tempfile.TemporaryDirectory() as directory:
+            result_directory = Path(directory)
+            write_metadata(
+                result_directory,
+                SegmentationMode.GPT_5_6_LAYOUT,
+            )
+
+            self.assertEqual(
+                read_metadata(result_directory),
+                {
+                    "segmentation_mode": "gpt-5.6-layout",
+                    "access_policy": "authenticated",
+                },
+            )
+
+    def test_legacy_result_without_metadata_is_public_standard(self):
+        with tempfile.TemporaryDirectory() as directory:
+            self.assertEqual(
+                read_metadata(Path(directory)),
+                {
+                    "segmentation_mode": "standard",
+                    "access_policy": "public",
+                },
+            )
+
+    def test_metadata_rejects_policy_that_does_not_match_mode(self):
+        with tempfile.TemporaryDirectory() as directory:
+            metadata_path = Path(directory) / "metadata.json"
+            metadata_path.write_text(json.dumps({
+                "segmentation_mode": "gpt-5.6-layout",
+                "access_policy": "public",
+            }))
+
+            with self.assertRaises(ValueError):
+                read_metadata(Path(directory))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test_detector_selection.py
+++ b/test_detector_selection.py
@@ -1,0 +1,78 @@
+import threading
+import time
+import unittest
+from concurrent.futures import ThreadPoolExecutor
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+import app
+from chapter_contract import SegmentationMode
+
+
+class DetectorSelectionTest(unittest.TestCase):
+    def test_process_chapter_builds_a_detector_for_each_request_mode(self):
+        captured_options = []
+
+        class RecordingDetector:
+            def __init__(self, options):
+                captured_options.append(options)
+
+            def parse_dir(self, _image_path):
+                return {"pages": [{"filename": "001.png", "panels": []}]}
+
+        with TemporaryDirectory() as directory, patch.multiple(
+            app,
+            DATA_DIR=app.Path(directory),
+            IMAGES_DIR=app.Path(directory) / "images",
+            JSONS_DIR=app.Path(directory) / "jsons",
+            Kumiko=RecordingDetector,
+            download_lmages=lambda _url, _path: 1,
+            save_file=lambda _info, path: app.Path(path).write_text("{}"),
+        ):
+            app.process_chapter(
+                "https://opchapters.com/chapter/standard",
+                SegmentationMode.STANDARD,
+            )
+            app.process_chapter(
+                "https://opchapters.com/chapter/premium",
+                SegmentationMode.GPT_5_6_LAYOUT,
+            )
+
+        self.assertEqual(captured_options[0]["panel_llm_mode"], "off")
+        self.assertEqual(captured_options[1]["panel_llm_mode"], "always")
+
+    def test_extractions_with_different_modes_remain_serialized(self):
+        state_lock = threading.Lock()
+        active = 0
+        maximum_active = 0
+        received_modes = []
+
+        def extractor(_chapter_url, mode):
+            nonlocal active, maximum_active
+            with state_lock:
+                active += 1
+                maximum_active = max(maximum_active, active)
+                received_modes.append(mode)
+            time.sleep(0.03)
+            with state_lock:
+                active -= 1
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            futures = [
+                executor.submit(
+                    app.run_extraction,
+                    extractor,
+                    f"https://opchapters.com/chapter/{mode.value}",
+                    mode,
+                )
+                for mode in SegmentationMode
+            ]
+            for future in futures:
+                future.result()
+
+        self.assertEqual(maximum_active, 1)
+        self.assertCountEqual(received_modes, list(SegmentationMode))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- adds closed `standard` and `gpt-5.6-layout` product modes with a backward-compatible Standard default
- keeps provider model identifiers server-controlled
- separates cache identity by normalized source URL and mode while preserving legacy Standard hashes
- stores chapter mode/access metadata and treats metadata-free legacy results as public Standard chapters
- makes chapter authentication optional while retaining required authentication for billing
- implements the complete Standard and GPT-5.6 creation/retrieval access matrix
- selects detector configuration per extraction request while preserving the global extraction lock
- returns stable machine-readable access errors
- documents the API contract, legacy behavior, model configuration, and API-first rollout

## Why

OnePanel is moving from a hard subscription paywall to a freemium model. Standard local panel detection should be publicly usable, while GPT-5.6 Layout creation remains a Pro benefit and its results require a signed-in account.

The API remains the authorization boundary; frontend visibility is not treated as a security control.

## Validation

- `.venv/bin/python -m pytest -q` — 63 passed
- `git diff --check` — passed

## Tracking

Closes OnePanelOrg/OnePanelNext#20
Closes OnePanelOrg/OnePanelNext#21
Closes OnePanelOrg/OnePanelNext#22
Closes OnePanelOrg/OnePanelNext#23
Closes OnePanelOrg/OnePanelNext#24
Closes OnePanelOrg/OnePanelNext#25
Closes OnePanelOrg/OnePanelNext#26
Closes OnePanelOrg/OnePanelNext#27
Closes OnePanelOrg/OnePanelNext#28
Closes OnePanelOrg/OnePanelNext#29
Closes OnePanelOrg/OnePanelNext#30
Closes OnePanelOrg/OnePanelNext#31
Closes OnePanelOrg/OnePanelNext#32
Closes OnePanelOrg/OnePanelNext#33
Closes OnePanelOrg/OnePanelNext#34

Part of OnePanelOrg/OnePanelNext#19.
