### PR TITLE
Add content-addressed comic file ingestion

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
     DATA_DIR=/data
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends libgl1 libglib2.0-0 \
+    && apt-get install -y --no-install-recommends libgl1 libglib2.0-0 unar \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
@@ -15,6 +15,6 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 
-RUN mkdir -p /data/images /data/jsons
+RUN mkdir -p /data/images /data/jsons /data/pages
 
 CMD ["sh", "-c", "uvicorn app:app --host 0.0.0.0 --port ${PORT:-8000} --workers 1"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,6 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 
-RUN mkdir -p /data/images /data/jsons /data/pages
+RUN mkdir -p /data/images /data/jsons
 
 CMD ["sh", "-c", "uvicorn app:app --host 0.0.0.0 --port ${PORT:-8000} --workers 1"]

--- a/README.md
+++ b/README.md
@@ -72,7 +72,8 @@ Creation and retrieval access:
 
 | Mode | Create | Retrieve |
 | --- | --- | --- |
-| `standard` | Anonymous or signed in; no subscription lookup | Public by unguessable chapter hash |
+| `standard` URL | Anonymous or signed in; no subscription lookup | Public by unguessable chapter hash |
+| `standard` upload | Signed-in account | Re-upload required after the browser session |
 | `gpt-5.6-layout` | Signed-in active Pro subscriber | Any signed-in account |
 
 Standard and GPT-5.6 Layout have different cache identities for the same

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Manga Panel Extractor
 
-Python service used by OnePanel to download the pages of a manga chapter, detect
-panel geometry, and return reader-layout JSON.
+Python service used by OnePanel to download or import the pages of a manga
+chapter, detect panel geometry, and return reader-layout JSON.
 
 This repository is the backend currently understood to be deployed on Railway.
 The deployment and billing facts supplied by the project owner are recorded in
@@ -11,7 +11,7 @@ be verified there.
 
 ## What it does
 
-Given a chapter URL, the service:
+Given a chapter URL or uploaded comic, the service:
 
 1. downloads matching PNG images from the chapter HTML;
 2. stores the original image URLs alongside the temporary downloads;
@@ -23,6 +23,10 @@ Given a chapter URL, the service:
 The chapter hash is the MD5 of the chapter URL after its query string is
 removed. Processing and caching are synchronous and local to the service
 instance.
+
+Uploads accept one CBZ, CBR, ZIP, RAR, or PDF, or a set of loose page images.
+Their cache identity is a SHA-256 digest of the ordered decoded page pixels, so
+container metadata and image encoding do not change chapter identity.
 
 ## API
 
@@ -44,7 +48,9 @@ Interactive API documentation is available at
 | --- | --- | --- |
 | `GET` | `/` | Basic process check; returns service status |
 | `POST` | `/v2/chapter` | Process a chapter and return its hash |
+| `POST` | `/v2/chapter/upload` | Process uploaded comic media and return its hash |
 | `GET` | `/v2/chapter/{chapter_hash}` | Read a cached Kumiko result |
+| `GET` | `/v2/pages/{content_digest}/{page_name}` | Read a normalized uploaded page |
 | `GET` | `/v2/billing/status` | Read the authenticated user's subscription |
 | `POST` | `/v2/billing/checkout` | Create a Stripe subscription Checkout |
 | `POST` | `/v2/billing/portal` | Open Stripe's customer billing portal |
@@ -73,6 +79,12 @@ Creation and retrieval access:
 Standard and GPT-5.6 Layout have different cache identities for the same
 normalized source URL. Standard retains the historical MD5 identity, and cached
 results without `metadata.json` are interpreted as public Standard results.
+
+The upload endpoint accepts multipart `files` plus an optional
+`segmentation_mode`. Send one container/PDF or one or more page images. Archive
+paths are never extracted directly, and the importer enforces compressed,
+expanded, per-page, page-count, pixel-count, and compression-ratio limits.
+Normalized pages are stored once across segmentation modes.
 
 Feedback body:
 
@@ -114,6 +126,11 @@ Railway MySQL reference-variable mappings and the required `feedback` table
 schema are documented in [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md).
 
 Do not commit `.env`; it is ignored by Git.
+
+`DATA_DIR` must be persistent in production; uploaded pages are stored under
+`pages/` and cached results under `jsons/`. Upload limits can be adjusted with
+`MAX_UPLOAD_BYTES`, `MAX_EXPANDED_BYTES`, `MAX_PAGE_BYTES`,
+`MAX_CHAPTER_IMAGES`, `MAX_IMAGE_PIXELS`, and `MAX_ARCHIVE_RATIO`.
 
 The provider model used by GPT-5.6 Layout is controlled only by the server
 environment:

--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ Interactive API documentation is available at
 | `POST` | `/v2/chapter` | Process a chapter and return its hash |
 | `POST` | `/v2/chapter/upload` | Process uploaded comic media and return its hash |
 | `GET` | `/v2/chapter/{chapter_hash}` | Read a cached Kumiko result |
-| `GET` | `/v2/pages/{content_digest}/{page_name}` | Read a normalized uploaded page |
 | `GET` | `/v2/billing/status` | Read the authenticated user's subscription |
 | `POST` | `/v2/billing/checkout` | Create a Stripe subscription Checkout |
 | `POST` | `/v2/billing/portal` | Open Stripe's customer billing portal |
@@ -84,7 +83,10 @@ The upload endpoint accepts multipart `files` plus an optional
 `segmentation_mode`. Send one container/PDF or one or more page images. Archive
 paths are never extracted directly, and the importer enforces compressed,
 expanded, per-page, page-count, pixel-count, and compression-ratio limits.
-Normalized pages are stored once across segmentation modes.
+Normalized pages are request-scoped and deleted immediately after analysis.
+Only the layout JSON is cached. The upload response contains transient data
+URLs for the current browser session; reopening it requires re-uploading.
+An identical re-upload reuses the cached JSON and skips panel analysis.
 
 Feedback body:
 
@@ -127,8 +129,9 @@ schema are documented in [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md).
 
 Do not commit `.env`; it is ignored by Git.
 
-`DATA_DIR` must be persistent in production; uploaded pages are stored under
-`pages/` and cached results under `jsons/`. Upload limits can be adjusted with
+`DATA_DIR` must be persistent in production for cached analysis JSON under
+`jsons/`. Downloaded, extracted, and normalized pages are temporary and are
+deleted after each request. Upload limits can be adjusted with
 `MAX_UPLOAD_BYTES`, `MAX_EXPANDED_BYTES`, `MAX_PAGE_BYTES`,
 `MAX_CHAPTER_IMAGES`, `MAX_IMAGE_PIXELS`, and `MAX_ARCHIVE_RATIO`.
 

--- a/app.py
+++ b/app.py
@@ -199,12 +199,17 @@ def process_uploaded_chapter(
     try:
         chapter_hash = upload_cache_key(ingested.content_digest, mode)
         result_file = JSONS_DIR / chapter_hash / "kumiko.json"
-        if result_file.exists():
+        cache_hit = result_file.exists()
+        if cache_hit:
             logger.info("uploaded chapter already processed")
             with result_file.open() as file:
                 info = json.load(file)
-            cache_hit = True
-        else:
+            if len(info.get("pages", [])) != len(ingested.page_names):
+                logger.warning("discarding invalid uploaded chapter cache")
+                shutil.rmtree(result_file.parent, ignore_errors=True)
+                cache_hit = False
+
+        if not cache_hit:
             image_urls = {
                 page_name: {
                     "page_index": page_index,
@@ -222,6 +227,15 @@ def process_uploaded_chapter(
                 raise HTTPException(
                     status_code=422,
                     detail="No supported chapter images were found; result was not cached",
+                )
+            info["pages"].sort(key=page_sort_key)
+            if len(info["pages"]) != len(ingested.page_names):
+                raise HTTPException(
+                    status_code=422,
+                    detail=(
+                        "One or more normalized pages could not be analyzed; "
+                        "result was not cached."
+                    ),
                 )
 
             result_directory = result_file.parent
@@ -302,12 +316,12 @@ async def post_chapter_v2(
 async def post_chapter_upload_v2(
     files: list[UploadFile] = File(...),
     segmentation_mode: SegmentationMode = Form(SegmentationMode.STANDARD),
-    user_id: Optional[str] = Depends(optional_user),
+    user_id: str = Depends(require_user),
 ):
     await authorize_creation(segmentation_mode, user_id)
     try:
         return await run_in_threadpool(
-            run_extraction,
+            run_upload_extraction,
             process_uploaded_chapter,
             files,
             segmentation_mode,
@@ -381,6 +395,20 @@ def run_extraction(extractor, chapter_url, *args):
     # in the initial single-instance deployment.
     with extraction_lock:
         return extractor(chapter_url, *args)
+
+
+def run_upload_extraction(extractor, uploads, *args):
+    # Do not let concurrent upload work queue enough blocked threads to starve
+    # health, billing, and chapter-retrieval requests.
+    if not extraction_lock.acquire(blocking=False):
+        raise HTTPException(
+            status_code=429,
+            detail="Another chapter is being processed. Please try again shortly.",
+        )
+    try:
+        return extractor(uploads, *args)
+    finally:
+        extraction_lock.release()
 
 @app.post("/v2/feedback")
 def post_feedback(data: dict):

--- a/app.py
+++ b/app.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import os, json
+import re
 import shutil
 import threading
 from pathlib import Path
@@ -12,9 +13,10 @@ from logging.handlers import TimedRotatingFileHandler
 from uuid import uuid4
 
 from dotenv import load_dotenv
-from fastapi import Depends, FastAPI, HTTPException
+from fastapi import Depends, FastAPI, File, Form, HTTPException, UploadFile
 from fastapi.concurrency import run_in_threadpool
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import FileResponse
 from pydantic import BaseModel
 
 # project
@@ -33,8 +35,10 @@ from chapter_contract import (
     chapter_cache_key,
     detector_options_for,
     read_metadata,
+    upload_cache_key,
     write_metadata,
 )
+from ingestion import IngestionError, UploadSource, ingest_uploads
 
 load_dotenv()
 
@@ -42,8 +46,10 @@ app = FastAPI()
 DATA_DIR = Path(os.environ.get("DATA_DIR", "./data")).resolve()
 IMAGES_DIR = DATA_DIR / "images"
 JSONS_DIR = DATA_DIR / "jsons"
+PAGES_DIR = DATA_DIR / "pages"
 IMAGES_DIR.mkdir(parents=True, exist_ok=True)
 JSONS_DIR.mkdir(parents=True, exist_ok=True)
+PAGES_DIR.mkdir(parents=True, exist_ok=True)
 extraction_lock = threading.Lock()
 
 origins = [
@@ -183,6 +189,65 @@ def process_chapter(
     finally:
         shutil.rmtree(image_path, ignore_errors=True)
 
+
+def process_uploaded_chapter(
+    uploads: list[UploadFile],
+    mode: SegmentationMode = SegmentationMode.STANDARD,
+):
+    ingested = ingest_uploads(
+        UploadSource(upload.filename or "upload", upload.file)
+        for upload in uploads
+    )
+    try:
+        chapter_hash = upload_cache_key(ingested.content_digest, mode)
+        result_file = JSONS_DIR / chapter_hash / "kumiko.json"
+        stored_pages = PAGES_DIR / ingested.content_digest
+        if result_file.exists():
+            if not stored_pages.exists():
+                shutil.copytree(ingested.directory, stored_pages)
+            logger.info("uploaded chapter already processed")
+            return {"chapter_hash": chapter_hash, "cache_hit": True}
+
+        image_urls = {
+            page_name: {
+                "page_index": page_index,
+                "source_url": (
+                    f"/api/onepanel/v2/pages/{ingested.content_digest}/{page_name}"
+                ),
+            }
+            for page_index, page_name in enumerate(ingested.page_names, start=1)
+        }
+        save_file(image_urls, str(ingested.directory / "img_dict.json"))
+
+        detector = Kumiko(detector_options_for(mode))
+        info = detector.parse_dir(str(ingested.directory))
+        if not info["pages"]:
+            raise HTTPException(
+                status_code=422,
+                detail="No supported chapter images were found; result was not cached",
+            )
+
+        if not stored_pages.exists():
+            stored_pages.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copytree(
+                ingested.directory,
+                stored_pages,
+                ignore=shutil.ignore_patterns("img_dict.json"),
+            )
+
+        result_directory = result_file.parent
+        result_directory.mkdir(parents=True, exist_ok=True)
+        write_metadata(result_directory, mode)
+        save_file(info, str(result_file))
+        logger.info(
+            "uploaded chapter extracted: content_digest=%s chapter_hash=%s",
+            ingested.content_digest,
+            chapter_hash,
+        )
+        return {"chapter_hash": chapter_hash, "cache_hit": False}
+    finally:
+        ingested.cleanup()
+
 async def authorize_creation(
     mode: SegmentationMode,
     user_id: Optional[str],
@@ -220,6 +285,30 @@ async def post_chapter_v2(
 
     return result
 
+
+@app.post("/v2/chapter/upload")
+async def post_chapter_upload_v2(
+    files: list[UploadFile] = File(...),
+    segmentation_mode: SegmentationMode = Form(SegmentationMode.STANDARD),
+    user_id: Optional[str] = Depends(optional_user),
+):
+    await authorize_creation(segmentation_mode, user_id)
+    try:
+        return await run_in_threadpool(
+            run_extraction,
+            process_uploaded_chapter,
+            files,
+            segmentation_mode,
+        )
+    except IngestionError as error:
+        raise HTTPException(
+            status_code=error.status_code,
+            detail=str(error),
+        ) from error
+    finally:
+        for upload in files:
+            await upload.close()
+
 @app.get("/v2/chapter/{chapter_hash}")
 async def get_chapter(
     chapter_hash: str,
@@ -244,6 +333,24 @@ async def get_chapter(
         page["pageIndex"] = page_index
 
     return result
+
+
+@app.get("/v2/pages/{content_digest}/{page_name}")
+async def get_uploaded_page(content_digest: str, page_name: str):
+    if (
+        len(content_digest) != 64
+        or any(character not in "0123456789abcdef" for character in content_digest)
+        or not re.fullmatch(r"\d{4}\.webp", page_name)
+    ):
+        raise HTTPException(status_code=404, detail="Page not found")
+    page_path = PAGES_DIR / content_digest / page_name
+    if not page_path.is_file():
+        raise HTTPException(status_code=404, detail="Page not found")
+    return FileResponse(
+        page_path,
+        media_type="image/webp",
+        headers={"Cache-Control": "public, max-age=31536000, immutable"},
+    )
 
 
 @app.get("/v2/billing/status")

--- a/app.py
+++ b/app.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import logging
 import os, json
-import re
+import base64
+import copy
 import shutil
 import threading
 from pathlib import Path
@@ -16,7 +17,6 @@ from dotenv import load_dotenv
 from fastapi import Depends, FastAPI, File, Form, HTTPException, UploadFile
 from fastapi.concurrency import run_in_threadpool
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import FileResponse
 from pydantic import BaseModel
 
 # project
@@ -46,10 +46,8 @@ app = FastAPI()
 DATA_DIR = Path(os.environ.get("DATA_DIR", "./data")).resolve()
 IMAGES_DIR = DATA_DIR / "images"
 JSONS_DIR = DATA_DIR / "jsons"
-PAGES_DIR = DATA_DIR / "pages"
 IMAGES_DIR.mkdir(parents=True, exist_ok=True)
 JSONS_DIR.mkdir(parents=True, exist_ok=True)
-PAGES_DIR.mkdir(parents=True, exist_ok=True)
 extraction_lock = threading.Lock()
 
 origins = [
@@ -201,50 +199,64 @@ def process_uploaded_chapter(
     try:
         chapter_hash = upload_cache_key(ingested.content_digest, mode)
         result_file = JSONS_DIR / chapter_hash / "kumiko.json"
-        stored_pages = PAGES_DIR / ingested.content_digest
         if result_file.exists():
-            if not stored_pages.exists():
-                shutil.copytree(ingested.directory, stored_pages)
             logger.info("uploaded chapter already processed")
-            return {"chapter_hash": chapter_hash, "cache_hit": True}
-
-        image_urls = {
-            page_name: {
-                "page_index": page_index,
-                "source_url": (
-                    f"/api/onepanel/v2/pages/{ingested.content_digest}/{page_name}"
-                ),
+            with result_file.open() as file:
+                info = json.load(file)
+            cache_hit = True
+        else:
+            image_urls = {
+                page_name: {
+                    "page_index": page_index,
+                    "source_url": (
+                        f"upload://{ingested.content_digest}/{page_name}"
+                    ),
+                }
+                for page_index, page_name in enumerate(ingested.page_names, start=1)
             }
-            for page_index, page_name in enumerate(ingested.page_names, start=1)
-        }
-        save_file(image_urls, str(ingested.directory / "img_dict.json"))
+            save_file(image_urls, str(ingested.directory / "img_dict.json"))
 
-        detector = Kumiko(detector_options_for(mode))
-        info = detector.parse_dir(str(ingested.directory))
-        if not info["pages"]:
+            detector = Kumiko(detector_options_for(mode))
+            info = detector.parse_dir(str(ingested.directory))
+            if not info["pages"]:
+                raise HTTPException(
+                    status_code=422,
+                    detail="No supported chapter images were found; result was not cached",
+                )
+
+            result_directory = result_file.parent
+            result_directory.mkdir(parents=True, exist_ok=True)
+            write_metadata(result_directory, mode)
+            # The cached artifact contains analysis only. Raw or normalized page
+            # bytes must never be persisted after this request.
+            save_file(info, str(result_file))
+            cache_hit = False
+            logger.info(
+                "uploaded chapter extracted: content_digest=%s chapter_hash=%s",
+                ingested.content_digest,
+                chapter_hash,
+            )
+
+        response_chapter = copy.deepcopy(info)
+        response_chapter["pages"].sort(key=page_sort_key)
+        if len(response_chapter["pages"]) != len(ingested.page_names):
             raise HTTPException(
-                status_code=422,
-                detail="No supported chapter images were found; result was not cached",
+                status_code=500,
+                detail="The analyzed chapter could not be matched to its pages.",
             )
+        for page, page_name in zip(
+            response_chapter["pages"],
+            ingested.page_names,
+        ):
+            page_path = ingested.directory / page_name
+            encoded = base64.b64encode(page_path.read_bytes()).decode("ascii")
+            page["image"] = f"data:image/webp;base64,{encoded}"
 
-        if not stored_pages.exists():
-            stored_pages.parent.mkdir(parents=True, exist_ok=True)
-            shutil.copytree(
-                ingested.directory,
-                stored_pages,
-                ignore=shutil.ignore_patterns("img_dict.json"),
-            )
-
-        result_directory = result_file.parent
-        result_directory.mkdir(parents=True, exist_ok=True)
-        write_metadata(result_directory, mode)
-        save_file(info, str(result_file))
-        logger.info(
-            "uploaded chapter extracted: content_digest=%s chapter_hash=%s",
-            ingested.content_digest,
-            chapter_hash,
-        )
-        return {"chapter_hash": chapter_hash, "cache_hit": False}
+        return {
+            "chapter_hash": chapter_hash,
+            "chapter": response_chapter,
+            "cache_hit": cache_hit,
+        }
     finally:
         ingested.cleanup()
 
@@ -327,30 +339,23 @@ async def get_chapter(
     authorize_retrieval(metadata, user_id)
     with result_file.open() as file:
         result = json.load(file)
+    if any(
+        str(page.get("image", "")).startswith("upload://")
+        for page in result.get("pages", [])
+    ):
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                "Uploaded chapters are session-only. Re-upload the source "
+                "to read it again."
+            ),
+        )
 
     result["pages"].sort(key=page_sort_key)
     for page_index, page in enumerate(result["pages"], start=1):
         page["pageIndex"] = page_index
 
     return result
-
-
-@app.get("/v2/pages/{content_digest}/{page_name}")
-async def get_uploaded_page(content_digest: str, page_name: str):
-    if (
-        len(content_digest) != 64
-        or any(character not in "0123456789abcdef" for character in content_digest)
-        or not re.fullmatch(r"\d{4}\.webp", page_name)
-    ):
-        raise HTTPException(status_code=404, detail="Page not found")
-    page_path = PAGES_DIR / content_digest / page_name
-    if not page_path.is_file():
-        raise HTTPException(status_code=404, detail="Page not found")
-    return FileResponse(
-        page_path,
-        media_type="image/webp",
-        headers={"Cache-Control": "public, max-age=31536000, immutable"},
-    )
 
 
 @app.get("/v2/billing/status")

--- a/chapter_contract.py
+++ b/chapter_contract.py
@@ -34,6 +34,13 @@ def chapter_cache_key(source_url: str, mode: SegmentationMode) -> str:
     return hashlib.md5(identity.encode()).hexdigest()
 
 
+def upload_cache_key(content_digest: str, mode: SegmentationMode) -> str:
+    """Identify extracted JSON independently from upload container metadata."""
+
+    identity = f"upload-v1\n{content_digest}\n{mode.value}"
+    return hashlib.sha256(identity.encode()).hexdigest()
+
+
 def access_policy_for(mode: SegmentationMode) -> AccessPolicy:
     if mode is SegmentationMode.STANDARD:
         return AccessPolicy.PUBLIC

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -5,7 +5,7 @@
 ```text
 Client
   |
-  | POST /v2/chapter
+  | POST /v2/chapter or POST /v2/chapter/upload
   v
 FastAPI (app.py)
   |
@@ -16,6 +16,12 @@ FastAPI (app.py)
   |     +-- select matching PNG/WebP <img> sources
   |     `-- write images/<hash>/ and img_dict.json
   |
+  +-- ingestion.ingest_uploads()
+  |     +-- safely read an archive, PDF, or loose images
+  |     +-- normalize pages to lossless WebP
+  |     +-- hash ordered decoded pixels
+  |     `-- reuse pages/<sha256>/ and mode-aware JSON when present
+  |
   +-- construct per-request Kumiko detector
   |     +-- standard -> local detector
   |     `-- gpt-5.6-layout -> server-selected quality vision model
@@ -23,8 +29,10 @@ FastAPI (app.py)
   `-- return result or chapter hash
 ```
 
-All chapter work happens in the API request process. There is no active queue,
-background job, object storage, or shared cache in the checked-in application.
+All chapter work happens in the API request process under one extraction lock.
+There is no active queue or shared cache in the checked-in application.
+`DATA_DIR` must therefore be a persistent volume and a single worker remains a
+deployment constraint.
 
 ## Components
 
@@ -32,6 +40,7 @@ background job, object storage, or shared cache in the checked-in application.
 | --- | --- | --- |
 | `app.py` | FastAPI application, routing, orchestration, CORS, logging | Active |
 | `utils.py` | HTML/image download, file discovery, JSON and image helpers | Active |
+| `ingestion.py` | Safe comic/PDF/image ingestion and content identity | Active |
 | `kumikolib.py`, `kcore/` | Bundled Kumiko page-layout algorithm and optional vision LLM detector | Active |
 | `feedback_service.py` | MySQL connection and feedback insert | Active for feedback endpoint |
 | `output.json` | Historical example output | Sample only |
@@ -49,6 +58,11 @@ images/<md5>/ (temporary during extraction)
 jsons/<md5>/
   kumiko.json
   metadata.json
+
+pages/<content-sha256>/
+  0001.webp
+  0002.webp
+  ...
 ```
 
 Downloaded pages use zero-padded sequential filenames and carry a `page_index`

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -20,7 +20,7 @@ FastAPI (app.py)
   |     +-- safely read an archive, PDF, or loose images
   |     +-- normalize pages to lossless WebP
   |     +-- hash ordered decoded pixels
-  |     `-- reuse pages/<sha256>/ and mode-aware JSON when present
+  |     `-- delete all staged and normalized pages after building the response
   |
   +-- construct per-request Kumiko detector
   |     +-- standard -> local detector
@@ -31,8 +31,8 @@ FastAPI (app.py)
 
 All chapter work happens in the API request process under one extraction lock.
 There is no active queue or shared cache in the checked-in application.
-`DATA_DIR` must therefore be a persistent volume and a single worker remains a
-deployment constraint.
+`DATA_DIR` persists analysis JSON only; a single worker remains a deployment
+constraint.
 
 ## Components
 
@@ -59,10 +59,6 @@ jsons/<md5>/
   kumiko.json
   metadata.json
 
-pages/<content-sha256>/
-  0001.webp
-  0002.webp
-  ...
 ```
 
 Downloaded pages use zero-padded sequential filenames and carry a `page_index`
@@ -70,6 +66,13 @@ in `img_dict.json`. This preserves source HTML order through extraction. The
 whole image directory is removed after extraction, whether processing succeeds
 or fails. Legacy results without an explicit index use natural numeric filename
 ordering.
+
+Uploads follow the same deletion rule. Archives, PDFs, loose images, extracted
+files, and normalized WebP pages live only in a request-scoped temporary
+directory. The response embeds pages as transient data URLs for the current
+browser session, while `kumiko.json` stores only `upload://` placeholders and
+layout data. A later read requires re-uploading the source; its content hash can
+still reuse the cached analysis.
 
 The HTTP API stores and returns `kumiko.json`. Older deployments also generated
 `panel_extracted.json` using `PanelExtractor`; that duplicate output is no

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -29,7 +29,7 @@ The repository includes:
 - a Dockerfile based on `python:3.10-slim`;
 - required OpenCV system libraries;
 - a single-worker Uvicorn start command bound to `${PORT:-8000}`;
-- `/data/images` and `/data/jsons` runtime directories; and
+- `/data/images`, `/data/jsons`, and `/data/pages` runtime directories; and
 - `DATA_DIR=/data`.
 
 There is no `railway.toml`, `railway.json`, Procfile, CI deployment workflow, or
@@ -37,6 +37,11 @@ production domain/service identifier in the repository. The Railway project
 dashboard is recorded above, but the health check, region, replicas, volume,
 environment variables, public domain, and billing controls must still be
 confirmed there.
+
+Comic uploads are sent directly from the browser to the Railway API. Confirm
+that Railway's request-size and request-duration limits accommodate
+`MAX_UPLOAD_BYTES`, and mount a persistent volume at `/data`; otherwise
+normalized uploaded pages and cached extraction results disappear on restart.
 
 ## Expected service configuration
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -29,7 +29,7 @@ The repository includes:
 - a Dockerfile based on `python:3.10-slim`;
 - required OpenCV system libraries;
 - a single-worker Uvicorn start command bound to `${PORT:-8000}`;
-- `/data/images`, `/data/jsons`, and `/data/pages` runtime directories; and
+- `/data/images` and `/data/jsons` runtime directories; and
 - `DATA_DIR=/data`.
 
 There is no `railway.toml`, `railway.json`, Procfile, CI deployment workflow, or
@@ -152,13 +152,14 @@ Deploy the API before the freemium frontend. After the API deployment, verify in
 this order:
 
 1. Existing legacy chapter hashes still retrieve as public Standard chapters.
-2. Anonymous Standard creation and retrieval succeed.
-3. Standard and GPT-5.6 Layout produce distinct hashes for the same source URL.
-4. Signed-out and free-account premium creation is rejected before extraction.
-5. Active Pro premium creation uses the configured server quality model.
-6. A signed-in free account can retrieve a premium result, while an anonymous
+2. Anonymous Standard URL creation and retrieval succeed.
+3. Comic upload requires an authenticated account.
+4. Standard and GPT-5.6 Layout produce distinct hashes for the same source URL.
+5. Signed-out and free-account premium creation is rejected before extraction.
+6. Active Pro premium creation uses the configured server quality model.
+7. A signed-in free account can retrieve a premium result, while an anonymous
    caller cannot.
-7. Deploy the frontend, then verify upgrade and Checkout continuation flows.
+8. Deploy the frontend, then verify upgrade and Checkout continuation flows.
 
 In Railway, record or verify:
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -50,9 +50,10 @@ Comic uploads are sent directly from the browser to the Railway API. Railway
 documents a maximum HTTP request duration of 15 minutes, while the frontend
 times uploads out after 10 minutes. Railway does not publish a maximum HTTP
 request-body size, so the configured 250 MB upload ceiling should be monitored
-with real uploads. The current 500 MB volume is smaller than the 750 MB expanded
-input ceiling; live-resize it to the Hobby plan's current 5 GB default before
-relying on uploaded-page retention at scale.
+with real uploads. The volume stores cached JSON only. Uploaded and downloaded
+page data is request-scoped and deleted immediately after analysis, so the
+750 MB expanded input ceiling applies to ephemeral container storage rather
+than persistent volume capacity.
 
 ## Expected service configuration
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -33,15 +33,26 @@ The repository includes:
 - `DATA_DIR=/data`.
 
 There is no `railway.toml`, `railway.json`, Procfile, CI deployment workflow, or
-production domain/service identifier in the repository. The Railway project
-dashboard is recorded above, but the health check, region, replicas, volume,
-environment variables, public domain, and billing controls must still be
-confirmed there.
+production domain/service identifier in the repository.
 
-Comic uploads are sent directly from the browser to the Railway API. Confirm
-that Railway's request-size and request-duration limits accommodate
-`MAX_UPLOAD_BYTES`, and mount a persistent volume at `/data`; otherwise
-normalized uploaded pages and cached extraction results disappear on restart.
+The production service configuration was verified through the Railway CLI on
+2026-07-31:
+
+- project `onepanel`, production environment;
+- service `Manga-Panel-Extractor`, Hobby plan, one `us-west2` replica;
+- Railway domain
+  `manga-panel-extractor-production.up.railway.app`;
+- Dockerfile build from the `master` branch;
+- persistent volume `manga-panel-extractor-volume`, mounted at `/data`, ready,
+  with 500 MB capacity and approximately 77 MB used at verification time.
+
+Comic uploads are sent directly from the browser to the Railway API. Railway
+documents a maximum HTTP request duration of 15 minutes, while the frontend
+times uploads out after 10 minutes. Railway does not publish a maximum HTTP
+request-body size, so the configured 250 MB upload ceiling should be monitored
+with real uploads. The current 500 MB volume is smaller than the 750 MB expanded
+input ceiling; live-resize it to the Hobby plan's current 5 GB default before
+relying on uploaded-page retention at scale.
 
 ## Expected service configuration
 

--- a/ingestion.py
+++ b/ingestion.py
@@ -121,21 +121,17 @@ def _zip_pages(path: Path) -> list[tuple[str, bytes]]:
         members.sort(key=lambda member: natural_sort_key(member.filename))
         _validate_page_count(len(members))
         for member in members:
-            expanded += member.file_size
+            with archive.open(member) as page:
+                data = _read_limited(page, MAX_PAGE_BYTES, member.filename)
+            expanded += len(data)
             if expanded > MAX_EXPANDED_BYTES:
                 raise IngestionError("The archive expands beyond the safety limit.", 413)
-            if member.file_size > MAX_PAGE_BYTES:
-                raise IngestionError(f"{member.filename} exceeds the page size limit.", 413)
             if (
                 member.compress_size > 0
-                and member.file_size / member.compress_size > MAX_ARCHIVE_RATIO
+                and len(data) / member.compress_size > MAX_ARCHIVE_RATIO
             ):
                 raise IngestionError("The archive has an unsafe compression ratio.", 400)
-            with archive.open(member) as page:
-                pages.append((
-                    _safe_filename(member.filename),
-                    _read_limited(page, MAX_PAGE_BYTES, member.filename),
-                ))
+            pages.append((_safe_filename(member.filename), data))
     return pages
 
 
@@ -155,30 +151,23 @@ def _rar_pages(path: Path) -> list[tuple[str, bytes]]:
         expanded = 0
         with archive:
             for member in members:
-                expanded += member.file_size
+                with archive.open(member) as page:
+                    data = _read_limited(page, MAX_PAGE_BYTES, member.filename)
+                expanded += len(data)
                 if expanded > MAX_EXPANDED_BYTES:
                     raise IngestionError(
                         "The archive expands beyond the safety limit.",
                         413,
                     )
-                if member.file_size > MAX_PAGE_BYTES:
-                    raise IngestionError(
-                        f"{member.filename} exceeds the page size limit.",
-                        413,
-                    )
                 if (
                     member.compress_size > 0
-                    and member.file_size / member.compress_size > MAX_ARCHIVE_RATIO
+                    and len(data) / member.compress_size > MAX_ARCHIVE_RATIO
                 ):
                     raise IngestionError(
                         "The archive has an unsafe compression ratio.",
                         400,
                     )
-                with archive.open(member) as page:
-                    pages.append((
-                        _safe_filename(member.filename),
-                        _read_limited(page, MAX_PAGE_BYTES, member.filename),
-                    ))
+                pages.append((_safe_filename(member.filename), data))
         return pages
     except IngestionError:
         raise

--- a/ingestion.py
+++ b/ingestion.py
@@ -1,0 +1,356 @@
+"""Turn uploaded comic files into a safe, canonical ordered page set."""
+
+from __future__ import annotations
+
+import hashlib
+import io
+import os
+import re
+import shutil
+import tempfile
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import BinaryIO, Iterable, Sequence
+
+import pypdfium2 as pdfium
+import rarfile
+from PIL import Image, ImageOps, UnidentifiedImageError
+
+
+SUPPORTED_IMAGE_EXTENSIONS = {
+    ".bmp",
+    ".gif",
+    ".jpeg",
+    ".jpg",
+    ".png",
+    ".tif",
+    ".tiff",
+    ".webp",
+}
+SUPPORTED_CONTAINER_EXTENSIONS = {".cbz", ".cbr", ".zip", ".rar", ".pdf"}
+SUPPORTED_UPLOAD_EXTENSIONS = SUPPORTED_IMAGE_EXTENSIONS | SUPPORTED_CONTAINER_EXTENSIONS
+
+MAX_UPLOAD_BYTES = int(os.environ.get("MAX_UPLOAD_BYTES", 250 * 1024 * 1024))
+MAX_EXPANDED_BYTES = int(os.environ.get("MAX_EXPANDED_BYTES", 750 * 1024 * 1024))
+MAX_PAGE_BYTES = int(os.environ.get("MAX_PAGE_BYTES", 40 * 1024 * 1024))
+MAX_PAGES = int(os.environ.get("MAX_CHAPTER_IMAGES", 100))
+MAX_IMAGE_PIXELS = int(os.environ.get("MAX_IMAGE_PIXELS", 40_000_000))
+MAX_ARCHIVE_RATIO = int(os.environ.get("MAX_ARCHIVE_RATIO", 250))
+COPY_CHUNK_BYTES = 1024 * 1024
+
+
+class IngestionError(ValueError):
+    def __init__(self, message: str, status_code: int = 400):
+        super().__init__(message)
+        self.status_code = status_code
+
+
+@dataclass(frozen=True)
+class UploadSource:
+    filename: str
+    stream: BinaryIO
+
+
+@dataclass
+class IngestedChapter:
+    directory: Path
+    content_digest: str
+    page_names: list[str]
+
+    def cleanup(self) -> None:
+        shutil.rmtree(self.directory.parent, ignore_errors=True)
+
+
+def natural_sort_key(value: str) -> list[tuple[int, object]]:
+    return [
+        (1, int(part)) if part.isdigit() else (0, part.casefold())
+        for part in re.split(r"(\d+)", value.replace("\\", "/"))
+    ]
+
+
+def supported_upload(filename: str) -> bool:
+    return Path(filename).suffix.lower() in SUPPORTED_UPLOAD_EXTENSIONS
+
+
+def _safe_filename(filename: str) -> str:
+    normalized = filename.replace("\\", "/")
+    return normalized.rsplit("/", 1)[-1]
+
+
+def _copy_limited(source: BinaryIO, destination: BinaryIO, maximum: int) -> int:
+    total = 0
+    while True:
+        chunk = source.read(COPY_CHUNK_BYTES)
+        if not chunk:
+            return total
+        total += len(chunk)
+        if total > maximum:
+            raise IngestionError(
+                f"Upload exceeds the {maximum // (1024 * 1024)} MB limit.",
+                413,
+            )
+        destination.write(chunk)
+
+
+def _read_limited(source: BinaryIO, maximum: int, label: str) -> bytes:
+    output = io.BytesIO()
+    try:
+        _copy_limited(source, output, maximum)
+    except IngestionError as error:
+        raise IngestionError(f"{label} exceeds the size limit.", 413) from error
+    return output.getvalue()
+
+
+def _zip_pages(path: Path) -> list[tuple[str, bytes]]:
+    try:
+        archive = zipfile.ZipFile(path)
+    except (OSError, zipfile.BadZipFile) as error:
+        raise IngestionError("The ZIP/CBZ file is invalid or damaged.") from error
+
+    pages: list[tuple[str, bytes]] = []
+    expanded = 0
+    with archive:
+        members = [
+            member
+            for member in archive.infolist()
+            if not member.is_dir()
+            and Path(member.filename).suffix.lower() in SUPPORTED_IMAGE_EXTENSIONS
+            and "__MACOSX/" not in member.filename.replace("\\", "/")
+        ]
+        members.sort(key=lambda member: natural_sort_key(member.filename))
+        _validate_page_count(len(members))
+        for member in members:
+            expanded += member.file_size
+            if expanded > MAX_EXPANDED_BYTES:
+                raise IngestionError("The archive expands beyond the safety limit.", 413)
+            if member.file_size > MAX_PAGE_BYTES:
+                raise IngestionError(f"{member.filename} exceeds the page size limit.", 413)
+            if (
+                member.compress_size > 0
+                and member.file_size / member.compress_size > MAX_ARCHIVE_RATIO
+            ):
+                raise IngestionError("The archive has an unsafe compression ratio.", 400)
+            with archive.open(member) as page:
+                pages.append((
+                    _safe_filename(member.filename),
+                    _read_limited(page, MAX_PAGE_BYTES, member.filename),
+                ))
+    return pages
+
+
+def _rar_pages(path: Path) -> list[tuple[str, bytes]]:
+    try:
+        archive = rarfile.RarFile(path)
+        members = [
+            member
+            for member in archive.infolist()
+            if not member.isdir()
+            and Path(member.filename).suffix.lower() in SUPPORTED_IMAGE_EXTENSIONS
+            and "__MACOSX/" not in member.filename.replace("\\", "/")
+        ]
+        members.sort(key=lambda member: natural_sort_key(member.filename))
+        _validate_page_count(len(members))
+        pages: list[tuple[str, bytes]] = []
+        expanded = 0
+        with archive:
+            for member in members:
+                expanded += member.file_size
+                if expanded > MAX_EXPANDED_BYTES:
+                    raise IngestionError(
+                        "The archive expands beyond the safety limit.",
+                        413,
+                    )
+                if member.file_size > MAX_PAGE_BYTES:
+                    raise IngestionError(
+                        f"{member.filename} exceeds the page size limit.",
+                        413,
+                    )
+                if (
+                    member.compress_size > 0
+                    and member.file_size / member.compress_size > MAX_ARCHIVE_RATIO
+                ):
+                    raise IngestionError(
+                        "The archive has an unsafe compression ratio.",
+                        400,
+                    )
+                with archive.open(member) as page:
+                    pages.append((
+                        _safe_filename(member.filename),
+                        _read_limited(page, MAX_PAGE_BYTES, member.filename),
+                    ))
+        return pages
+    except IngestionError:
+        raise
+    except rarfile.NeedFirstVolume as error:
+        raise IngestionError("Multi-volume RAR/CBR files are not supported.") from error
+    except (rarfile.Error, OSError) as error:
+        raise IngestionError(
+            "The RAR/CBR file is invalid, damaged, or uses an unsupported variant."
+        ) from error
+
+
+def _pdf_pages(path: Path) -> list[tuple[str, bytes]]:
+    try:
+        document = pdfium.PdfDocument(path)
+    except Exception as error:
+        raise IngestionError("The PDF file is invalid, damaged, or encrypted.") from error
+
+    try:
+        _validate_page_count(len(document))
+        pages = []
+        expanded = 0
+        for index in range(len(document)):
+            page = document[index]
+            try:
+                width, height = page.get_size()
+                if width * height * 4 > MAX_IMAGE_PIXELS:
+                    raise IngestionError(
+                        f"PDF page {index + 1} exceeds the pixel limit.",
+                        413,
+                    )
+                bitmap = page.render(scale=2)
+                image = bitmap.to_pil()
+                output = io.BytesIO()
+                image.save(output, format="PNG", optimize=True)
+                data = output.getvalue()
+                expanded += len(data)
+                if len(data) > MAX_PAGE_BYTES or expanded > MAX_EXPANDED_BYTES:
+                    raise IngestionError(
+                        "The rendered PDF exceeds the expanded size limit.",
+                        413,
+                    )
+                pages.append((f"page-{index + 1:04d}.png", data))
+            finally:
+                page.close()
+        return pages
+    except IngestionError:
+        raise
+    except Exception as error:
+        raise IngestionError("The PDF could not be converted into page images.") from error
+    finally:
+        document.close()
+
+
+def _validate_page_count(count: int) -> None:
+    if count == 0:
+        raise IngestionError("No supported page images were found.")
+    if count > MAX_PAGES:
+        raise IngestionError(f"A chapter can contain at most {MAX_PAGES} pages.", 413)
+
+
+def _canonicalize_page(data: bytes, destination: Path) -> bytes:
+    Image.MAX_IMAGE_PIXELS = MAX_IMAGE_PIXELS
+    try:
+        with Image.open(io.BytesIO(data)) as source:
+            source.seek(0)
+            if source.width * source.height > MAX_IMAGE_PIXELS:
+                raise IngestionError(
+                    f"A page exceeds the {MAX_IMAGE_PIXELS:,}-pixel limit.",
+                    413,
+                )
+            image = ImageOps.exif_transpose(source).convert("RGB")
+            if image.width < 1 or image.height < 1:
+                raise IngestionError("A page image has invalid dimensions.")
+            pixel_count = image.width * image.height
+            if pixel_count > MAX_IMAGE_PIXELS:
+                raise IngestionError(
+                    f"A page exceeds the {MAX_IMAGE_PIXELS:,}-pixel limit.",
+                    413,
+                )
+
+            digest = hashlib.sha256()
+            digest.update(image.width.to_bytes(4, "big"))
+            digest.update(image.height.to_bytes(4, "big"))
+            digest.update(image.tobytes())
+            image.save(destination, format="WEBP", lossless=True, method=4)
+            return digest.digest()
+    except IngestionError:
+        raise
+    except (
+        Image.DecompressionBombError,
+        UnidentifiedImageError,
+        OSError,
+        ValueError,
+    ) as error:
+        raise IngestionError("A page is not a valid supported image.") from error
+
+
+def _raw_pages(
+    staged: Sequence[tuple[str, Path]],
+) -> list[tuple[str, bytes]]:
+    pages = []
+    for filename, path in sorted(staged, key=lambda item: natural_sort_key(item[0])):
+        with path.open("rb") as page:
+            pages.append((
+                _safe_filename(filename),
+                _read_limited(page, MAX_PAGE_BYTES, filename),
+            ))
+    _validate_page_count(len(pages))
+    return pages
+
+
+def ingest_uploads(sources: Iterable[UploadSource]) -> IngestedChapter:
+    """Ingest one container/PDF or an ordered set of loose page images."""
+
+    working_directory = Path(tempfile.mkdtemp(prefix="onepanel-upload-"))
+    staged: list[tuple[str, Path]] = []
+    total_upload_bytes = 0
+    try:
+        for index, source in enumerate(sources):
+            filename = _safe_filename(source.filename)
+            extension = Path(filename).suffix.lower()
+            if extension not in SUPPORTED_UPLOAD_EXTENSIONS:
+                raise IngestionError(f"{filename or 'File'} has an unsupported format.")
+            staged_path = working_directory / f"upload-{index:04d}{extension}"
+            with staged_path.open("wb") as output:
+                remaining = MAX_UPLOAD_BYTES - total_upload_bytes
+                if remaining <= 0:
+                    raise IngestionError("Uploads exceed the total size limit.", 413)
+                total_upload_bytes += _copy_limited(source.stream, output, remaining)
+            staged.append((filename, staged_path))
+
+        if not staged:
+            raise IngestionError("Choose at least one file to upload.")
+
+        container_files = [
+            item
+            for item in staged
+            if Path(item[0]).suffix.lower() in SUPPORTED_CONTAINER_EXTENSIONS
+        ]
+        if container_files and len(staged) != 1:
+            raise IngestionError(
+                "Upload one archive or PDF at a time, or select page images only."
+            )
+
+        if container_files:
+            filename, path = container_files[0]
+            extension = Path(filename).suffix.lower()
+            if extension in {".zip", ".cbz"}:
+                raw_pages = _zip_pages(path)
+            elif extension in {".rar", ".cbr"}:
+                raw_pages = _rar_pages(path)
+            else:
+                raw_pages = _pdf_pages(path)
+        else:
+            raw_pages = _raw_pages(staged)
+
+        pages_directory = working_directory / "pages"
+        pages_directory.mkdir()
+        chapter_digest = hashlib.sha256()
+        page_names = []
+        for index, (_, data) in enumerate(raw_pages, start=1):
+            page_name = f"{index:04d}.webp"
+            page_digest = _canonicalize_page(data, pages_directory / page_name)
+            chapter_digest.update(index.to_bytes(4, "big"))
+            chapter_digest.update(page_digest)
+            page_names.append(page_name)
+
+        return IngestedChapter(
+            directory=pages_directory,
+            content_digest=chapter_digest.hexdigest(),
+            page_names=page_names,
+        )
+    except Exception:
+        shutil.rmtree(working_directory, ignore_errors=True)
+        raise

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,9 @@ numpy==1.24.2
 opencv-python==4.7.0.72
 packaging==23.1
 Pillow==9.5.0
+pypdfium2==5.2.0
+python-multipart==0.0.20
+rarfile==4.2
 pydantic==1.10.7
 python-dotenv==1.0.0
 PyWavelets==1.4.1

--- a/test_app_chapters.py
+++ b/test_app_chapters.py
@@ -1,4 +1,5 @@
 import asyncio
+import io
 import json
 import tempfile
 import unittest
@@ -6,6 +7,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from fastapi import HTTPException
+from PIL import Image
 
 import app
 from chapter_contract import SegmentationMode, chapter_cache_key
@@ -17,12 +19,15 @@ class ChapterProcessingTest(unittest.TestCase):
         data_directory = Path(self.temporary_directory.name)
         self.images_directory = data_directory / "images"
         self.results_directory = data_directory / "jsons"
+        self.pages_directory = data_directory / "pages"
         self.images_directory.mkdir()
         self.results_directory.mkdir()
+        self.pages_directory.mkdir()
         self.directories = patch.multiple(
             app,
             IMAGES_DIR=self.images_directory,
             JSONS_DIR=self.results_directory,
+            PAGES_DIR=self.pages_directory,
         )
         self.directories.start()
 
@@ -88,6 +93,45 @@ class ChapterProcessingTest(unittest.TestCase):
 
         self.assertNotEqual(standard["chapter_hash"], premium["chapter_hash"])
         self.assertEqual(download_images.call_count, 2)
+
+    @patch("app.Kumiko")
+    def test_uploaded_chapter_uses_content_cache_and_persists_pages(self, kumiko):
+        image = io.BytesIO()
+        Image.new("RGB", (24, 32), "white").save(image, format="PNG")
+
+        detector = MagicMock()
+        detector.parse_dir.return_value = {
+            "pageCount": 1,
+            "pages": [{"filename": "0001.webp", "panels": [{"path": "0 0"}]}],
+        }
+        kumiko.return_value = detector
+
+        def upload():
+            return MagicMock(filename="page.png", file=io.BytesIO(image.getvalue()))
+
+        first = app.process_uploaded_chapter(
+            [upload()],
+            SegmentationMode.STANDARD,
+        )
+        second = app.process_uploaded_chapter(
+            [upload()],
+            SegmentationMode.STANDARD,
+        )
+
+        self.assertFalse(first["cache_hit"])
+        self.assertTrue(second["cache_hit"])
+        self.assertEqual(first["chapter_hash"], second["chapter_hash"])
+        self.assertEqual(detector.parse_dir.call_count, 1)
+        stored_pages = list(self.pages_directory.glob("*/0001.webp"))
+        self.assertEqual(len(stored_pages), 1)
+        result = json.loads(
+            (
+                self.results_directory
+                / first["chapter_hash"]
+                / "kumiko.json"
+            ).read_text()
+        )
+        self.assertEqual(result["pageCount"], 1)
 
     def test_missing_result_is_not_found(self):
         chapter_hash = chapter_cache_key(

--- a/test_app_chapters.py
+++ b/test_app_chapters.py
@@ -110,14 +110,23 @@ class ChapterProcessingTest(unittest.TestCase):
         def upload():
             return MagicMock(filename="page.png", file=io.BytesIO(image.getvalue()))
 
-        first = app.process_uploaded_chapter(
-            [upload()],
-            SegmentationMode.STANDARD,
-        )
-        second = app.process_uploaded_chapter(
-            [upload()],
-            SegmentationMode.STANDARD,
-        )
+        temporary_roots = []
+        real_ingest_uploads = app.ingest_uploads
+
+        def capture_ingestion(*args, **kwargs):
+            chapter = real_ingest_uploads(*args, **kwargs)
+            temporary_roots.append(chapter.directory.parent)
+            return chapter
+
+        with patch("app.ingest_uploads", side_effect=capture_ingestion):
+            first = app.process_uploaded_chapter(
+                [upload()],
+                SegmentationMode.STANDARD,
+            )
+            second = app.process_uploaded_chapter(
+                [upload()],
+                SegmentationMode.STANDARD,
+            )
 
         self.assertFalse(first["cache_hit"])
         self.assertTrue(second["cache_hit"])
@@ -143,7 +152,33 @@ class ChapterProcessingTest(unittest.TestCase):
         self.assertEqual(result["pageCount"], 1)
         self.assertTrue(result["pages"][0]["image"].startswith("upload://"))
         self.assertNotIn("data:image", json.dumps(result))
-        self.assertEqual(list(self.results_directory.parent.rglob("*.webp")), [])
+        self.assertTrue(temporary_roots)
+        self.assertTrue(all(not root.exists() for root in temporary_roots))
+
+    @patch("app.Kumiko")
+    def test_page_count_mismatch_is_not_cached(self, kumiko):
+        image = io.BytesIO()
+        Image.new("RGB", (24, 32), "white").save(image, format="PNG")
+        detector = MagicMock()
+        detector.parse_dir.return_value = {
+            "pageCount": 1,
+            "pages": [{
+                "filename": "0001.webp",
+                "image": "upload://digest/0001.webp",
+                "panels": [{"path": "0 0"}],
+            }],
+        }
+        kumiko.return_value = detector
+        uploads = [
+            MagicMock(filename=f"{index}.png", file=io.BytesIO(image.getvalue()))
+            for index in (1, 2)
+        ]
+
+        with self.assertRaises(HTTPException) as raised:
+            app.process_uploaded_chapter(uploads, SegmentationMode.STANDARD)
+
+        self.assertEqual(raised.exception.status_code, 422)
+        self.assertEqual(list(self.results_directory.rglob("kumiko.json")), [])
 
     def test_cached_upload_requires_reupload_for_later_retrieval(self):
         chapter_hash = "uploaded"
@@ -157,6 +192,18 @@ class ChapterProcessingTest(unittest.TestCase):
             asyncio.run(app.get_chapter(chapter_hash, None))
 
         self.assertEqual(raised.exception.status_code, 409)
+
+    def test_concurrent_upload_is_rejected_without_running_extractor(self):
+        extractor = MagicMock()
+        app.extraction_lock.acquire()
+        try:
+            with self.assertRaises(HTTPException) as raised:
+                app.run_upload_extraction(extractor, [])
+        finally:
+            app.extraction_lock.release()
+
+        self.assertEqual(raised.exception.status_code, 429)
+        extractor.assert_not_called()
 
     def test_missing_result_is_not_found(self):
         chapter_hash = chapter_cache_key(

--- a/test_app_chapters.py
+++ b/test_app_chapters.py
@@ -19,15 +19,12 @@ class ChapterProcessingTest(unittest.TestCase):
         data_directory = Path(self.temporary_directory.name)
         self.images_directory = data_directory / "images"
         self.results_directory = data_directory / "jsons"
-        self.pages_directory = data_directory / "pages"
         self.images_directory.mkdir()
         self.results_directory.mkdir()
-        self.pages_directory.mkdir()
         self.directories = patch.multiple(
             app,
             IMAGES_DIR=self.images_directory,
             JSONS_DIR=self.results_directory,
-            PAGES_DIR=self.pages_directory,
         )
         self.directories.start()
 
@@ -95,14 +92,18 @@ class ChapterProcessingTest(unittest.TestCase):
         self.assertEqual(download_images.call_count, 2)
 
     @patch("app.Kumiko")
-    def test_uploaded_chapter_uses_content_cache_and_persists_pages(self, kumiko):
+    def test_uploaded_chapter_reuses_json_and_deletes_all_page_files(self, kumiko):
         image = io.BytesIO()
         Image.new("RGB", (24, 32), "white").save(image, format="PNG")
 
         detector = MagicMock()
         detector.parse_dir.return_value = {
             "pageCount": 1,
-            "pages": [{"filename": "0001.webp", "panels": [{"path": "0 0"}]}],
+            "pages": [{
+                "filename": "0001.webp",
+                "image": "upload://digest/0001.webp",
+                "panels": [{"path": "0 0"}],
+            }],
         }
         kumiko.return_value = detector
 
@@ -122,8 +123,16 @@ class ChapterProcessingTest(unittest.TestCase):
         self.assertTrue(second["cache_hit"])
         self.assertEqual(first["chapter_hash"], second["chapter_hash"])
         self.assertEqual(detector.parse_dir.call_count, 1)
-        stored_pages = list(self.pages_directory.glob("*/0001.webp"))
-        self.assertEqual(len(stored_pages), 1)
+        self.assertTrue(
+            first["chapter"]["pages"][0]["image"].startswith(
+                "data:image/webp;base64,"
+            )
+        )
+        self.assertTrue(
+            second["chapter"]["pages"][0]["image"].startswith(
+                "data:image/webp;base64,"
+            )
+        )
         result = json.loads(
             (
                 self.results_directory
@@ -132,6 +141,22 @@ class ChapterProcessingTest(unittest.TestCase):
             ).read_text()
         )
         self.assertEqual(result["pageCount"], 1)
+        self.assertTrue(result["pages"][0]["image"].startswith("upload://"))
+        self.assertNotIn("data:image", json.dumps(result))
+        self.assertEqual(list(self.results_directory.parent.rglob("*.webp")), [])
+
+    def test_cached_upload_requires_reupload_for_later_retrieval(self):
+        chapter_hash = "uploaded"
+        result_directory = self.results_directory / chapter_hash
+        result_directory.mkdir()
+        (result_directory / "kumiko.json").write_text(json.dumps({
+            "pages": [{"image": "upload://digest/0001.webp"}],
+        }))
+
+        with self.assertRaises(HTTPException) as raised:
+            asyncio.run(app.get_chapter(chapter_hash, None))
+
+        self.assertEqual(raised.exception.status_code, 409)
 
     def test_missing_result_is_not_found(self):
         chapter_hash = chapter_cache_key(

--- a/test_chapter_contract.py
+++ b/test_chapter_contract.py
@@ -14,6 +14,7 @@ from chapter_contract import (
     chapter_cache_key,
     detector_options_for,
     read_metadata,
+    upload_cache_key,
     write_metadata,
 )
 
@@ -75,6 +76,15 @@ class ChapterContractTest(unittest.TestCase):
             chapter_cache_key(source_url, SegmentationMode.STANDARD),
             chapter_cache_key(source_url, SegmentationMode.GPT_5_6_LAYOUT),
         )
+
+    def test_uploaded_content_identity_is_provider_independent_and_mode_aware(self):
+        digest = "a" * 64
+
+        standard = upload_cache_key(digest, SegmentationMode.STANDARD)
+        premium = upload_cache_key(digest, SegmentationMode.GPT_5_6_LAYOUT)
+
+        self.assertEqual(len(standard), 64)
+        self.assertNotEqual(standard, premium)
 
     def test_provider_model_is_server_controlled(self):
         with patch.dict(

--- a/test_ingestion.py
+++ b/test_ingestion.py
@@ -111,6 +111,17 @@ class UploadIngestionTest(unittest.TestCase):
                     UploadSource("chapter.cbz", io.BytesIO(archive)),
                 ])
 
+    def test_enforces_cumulative_limit_from_bytes_actually_read(self):
+        archive = zip_bytes([
+            ("1.png", image_bytes("white")),
+            ("2.png", image_bytes("black")),
+        ])
+        with patch("ingestion.MAX_EXPANDED_BYTES", len(image_bytes("white"))):
+            with self.assertRaisesRegex(IngestionError, "safety limit"):
+                ingest_uploads([
+                    UploadSource("chapter.cbz", io.BytesIO(archive)),
+                ])
+
     def test_natural_sort_handles_nested_numeric_names(self):
         names = ["book/10.png", "book/2.png", "book/1.png"]
         self.assertEqual(

--- a/test_ingestion.py
+++ b/test_ingestion.py
@@ -1,0 +1,123 @@
+import io
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+from unittest.mock import patch
+
+from PIL import Image
+
+from ingestion import IngestionError, UploadSource, ingest_uploads, natural_sort_key
+
+
+def image_bytes(colour, image_format="PNG"):
+    output = io.BytesIO()
+    Image.new("RGB", (24, 32), colour).save(output, format=image_format)
+    return output.getvalue()
+
+
+def zip_bytes(entries):
+    output = io.BytesIO()
+    with zipfile.ZipFile(output, "w") as archive:
+        for name, data in entries:
+            archive.writestr(name, data)
+    return output.getvalue()
+
+
+class UploadIngestionTest(unittest.TestCase):
+    def test_loose_images_are_naturally_sorted_and_normalized(self):
+        chapter = ingest_uploads([
+            UploadSource("10.jpg", io.BytesIO(image_bytes("red", "JPEG"))),
+            UploadSource("2.png", io.BytesIO(image_bytes("blue"))),
+        ])
+        self.addCleanup(chapter.cleanup)
+
+        self.assertEqual(chapter.page_names, ["0001.webp", "0002.webp"])
+        with Image.open(chapter.directory / "0001.webp") as first:
+            self.assertEqual(first.getpixel((0, 0)), (0, 0, 255))
+
+    def test_container_metadata_does_not_change_content_identity(self):
+        pages = [
+            ("Comic/1.png", image_bytes("white")),
+            ("Comic/2.png", image_bytes("black")),
+        ]
+        first = ingest_uploads([
+            UploadSource("chapter.cbz", io.BytesIO(zip_bytes(pages))),
+        ])
+        second = ingest_uploads([
+            UploadSource(
+                "chapter.zip",
+                io.BytesIO(zip_bytes([("notes.txt", b"ignored"), *pages])),
+            ),
+        ])
+        self.addCleanup(first.cleanup)
+        self.addCleanup(second.cleanup)
+
+        self.assertEqual(first.content_digest, second.content_digest)
+
+    def test_equivalent_pixel_data_has_the_same_identity_across_image_formats(self):
+        png = ingest_uploads([
+            UploadSource("1.png", io.BytesIO(image_bytes("red", "PNG"))),
+        ])
+        bmp = ingest_uploads([
+            UploadSource("1.bmp", io.BytesIO(image_bytes("red", "BMP"))),
+        ])
+        self.addCleanup(png.cleanup)
+        self.addCleanup(bmp.cleanup)
+
+        self.assertEqual(png.content_digest, bmp.content_digest)
+
+    def test_pdf_pages_are_rasterized_in_document_order(self):
+        pdf = io.BytesIO()
+        images = [
+            Image.new("RGB", (24, 32), "red"),
+            Image.new("RGB", (24, 32), "blue"),
+        ]
+        images[0].save(pdf, format="PDF", save_all=True, append_images=images[1:])
+
+        chapter = ingest_uploads([
+            UploadSource("chapter.pdf", io.BytesIO(pdf.getvalue())),
+        ])
+        self.addCleanup(chapter.cleanup)
+
+        self.assertEqual(chapter.page_names, ["0001.webp", "0002.webp"])
+
+    def test_rejects_mixed_containers_and_images(self):
+        with self.assertRaisesRegex(IngestionError, "one archive or PDF"):
+            ingest_uploads([
+                UploadSource("chapter.cbz", io.BytesIO(zip_bytes([
+                    ("1.png", image_bytes("white")),
+                ]))),
+                UploadSource("cover.png", io.BytesIO(image_bytes("white"))),
+            ])
+
+    def test_rejects_archives_without_pages(self):
+        with self.assertRaisesRegex(IngestionError, "No supported page images"):
+            ingest_uploads([
+                UploadSource(
+                    "chapter.cbz",
+                    io.BytesIO(zip_bytes([("README.txt", b"hello")])),
+                ),
+            ])
+
+    def test_enforces_page_count_limit_before_extraction(self):
+        archive = zip_bytes([
+            (f"{index}.png", image_bytes("white"))
+            for index in range(3)
+        ])
+        with patch("ingestion.MAX_PAGES", 2):
+            with self.assertRaisesRegex(IngestionError, "at most 2 pages"):
+                ingest_uploads([
+                    UploadSource("chapter.cbz", io.BytesIO(archive)),
+                ])
+
+    def test_natural_sort_handles_nested_numeric_names(self):
+        names = ["book/10.png", "book/2.png", "book/1.png"]
+        self.assertEqual(
+            sorted(names, key=natural_sort_key),
+            ["book/1.png", "book/2.png", "book/10.png"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- Adds authenticated multipart ingestion for CBZ, CBR, ZIP, RAR, PDF, and loose page images.
- Normalizes decoded pages in request-scoped temporary storage and deletes every uploaded, extracted, normalized, or URL-downloaded image after analysis.
- Caches only panel/layout JSON and reuses it for identical content hashes.
- Returns transient page data for the current browser session; refresh requires re-uploading.
- Enforces actual streamed-byte, per-page, page-count, pixel, and compression-ratio limits.
- Rejects concurrent uploads with 429 instead of queuing blocked worker threads.
- Validates detector output before cache writes and discards invalid historical cache entries.

## Deployment

- The existing Railway volume at /data persists analysis JSON only.
- Railway documents a 15-minute request duration; the frontend times out after 10 minutes. Railway does not publish a request-body limit, so the configured 250 MB ceiling requires production monitoring.
- Deploy this backend before the frontend PR.

## Validation

- python -m unittest discover — 58 tests passed.
- python -m py_compile app.py ingestion.py chapter_contract.py.
- Local Claude Sonnet re-review found no remaining actionable defects.
- Diff whitespace checks passed.