### PR TITLE
Support TCB chapter extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,10 +156,13 @@ API modes. LLM results are cached by image hash and model under
 
 ## Current source compatibility
 
-The downloader accepts `.png` and `.webp` image `src` values whose absolute URL
-begins with `https://i`. URL query strings and uppercase extensions are
-supported. Sites using lazy-loading attributes, relative URLs, different host
-patterns, or other image formats still require an adapter.
+Chapter URLs must use HTTPS and come from `opchapters.com` or
+`tcbonepiecechapters.com` (with or without `www`). OP Chapters pages accept
+`.png` and `.webp` image sources whose absolute URL begins with `https://i`.
+TCB chapter pages use their ordered `fixed-ratio-content` reader images from
+`cdn.onepiecechapters.com`, with `.jpg`, `.jpeg`, `.png`, and `.webp` supported.
+URL query strings and uppercase extensions are supported. Other sites and
+lazy-loading attributes still require an adapter.
 
 An extraction that finds zero usable pages returns HTTP 422 and is not cached.
 

--- a/app.py
+++ b/app.py
@@ -126,10 +126,15 @@ def validate_chapter_url(chapter_url: str) -> str:
     if parsed.scheme != "https" or parsed.hostname not in {
         "opchapters.com",
         "www.opchapters.com",
+        "tcbonepiecechapters.com",
+        "www.tcbonepiecechapters.com",
     }:
         raise HTTPException(
             status_code=400,
-            detail="Only HTTPS URLs from opchapters.com are supported",
+            detail=(
+                "Only HTTPS URLs from opchapters.com and "
+                "tcbonepiecechapters.com are supported"
+            ),
         )
     return chapter_url
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -13,7 +13,7 @@ FastAPI (app.py)
   |
   +-- utils.download_lmages()
   |     +-- fetch chapter HTML
-  |     +-- select matching PNG/WebP <img> sources
+  |     +-- select matching OP Chapters or TCB reader images in page order
   |     `-- write images/<hash>/ and img_dict.json
   |
   +-- ingestion.ingest_uploads()

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -65,7 +65,7 @@ contain user-provided or sensitive text.
 | Symptom | Likely cause |
 | --- | --- |
 | Service does not become healthy | Start command does not bind to `$PORT`, dependency/build failure, or application import failure |
-| Chapter returns HTTP 422 with no supported images | Source images do not match the supported `https://i*.png`/`https://i*.webp` pattern, site HTML changed, or lazy-loaded images use another attribute |
+| Chapter returns HTTP 422 with no supported images | OP images do not match the supported `https://i*` PNG/WebP pattern, TCB reader markup or CDN paths changed, or lazy-loaded images use another attribute |
 | Request fails after a restart | Local cache was ephemeral |
 | `GET /v2/chapter/{hash}` returns 404 | Hash was never generated on this instance, cache was lost, or another replica owns it |
 | Chapter or billing request returns 401 | Clerk token is missing, expired, has the wrong issuer, or has an unauthorized `azp` |

--- a/test_app_chapters.py
+++ b/test_app_chapters.py
@@ -217,14 +217,23 @@ class ChapterProcessingTest(unittest.TestCase):
         self.assertEqual(raised.exception.status_code, 404)
 
     def test_chapter_url_validation_accepts_supported_https_host(self):
-        source_url = "https://www.opchapters.com/chapter/1?date=latest"
-
-        self.assertEqual(app.validate_chapter_url(source_url), source_url)
+        for source_url in (
+            "https://www.opchapters.com/chapter/1?date=latest",
+            (
+                "https://tcbonepiecechapters.com/chapters/7996/"
+                "one-piece-chapter-1189"
+            ),
+            "https://www.tcbonepiecechapters.com/chapters/7995/chapter",
+        ):
+            with self.subTest(source_url=source_url):
+                self.assertEqual(app.validate_chapter_url(source_url), source_url)
 
     def test_chapter_url_validation_rejects_other_origins(self):
         for source_url in (
             "http://opchapters.com/chapter/1",
+            "http://tcbonepiecechapters.com/chapters/7996/chapter",
             "https://opchapters.com.attacker.example/chapter/1",
+            "https://tcbonepiecechapters.com.attacker.example/chapters/1",
             "https://example.com/chapter/1",
         ):
             with self.subTest(source_url=source_url):

--- a/test_utils.py
+++ b/test_utils.py
@@ -2,7 +2,7 @@ import os
 import tempfile
 import unittest
 
-from utils import list_files, name_requirements
+from utils import extract_chapter_image_urls, list_files, name_requirements
 from kumikolib import Kumiko, natural_sort_key, page_sort_key
 
 
@@ -19,6 +19,41 @@ class ImageSourceTests(unittest.TestCase):
         self.assertFalse(name_requirements("/chapter/page.webp"))
         self.assertFalse(name_requirements("https://cdn.example/chapter/page.webp"))
         self.assertFalse(name_requirements("https://i.example/chapter/page.jpg"))
+
+    def test_accepts_tcb_chapter_image_cdn(self):
+        self.assertTrue(
+            name_requirements(
+                "https://cdn.onepiecechapters.com/file/CDN-M-A-N/page.png"
+            )
+        )
+        self.assertTrue(
+            name_requirements(
+                "https://cdn.onepiecechapters.com/file/CDN-M-A-N/page.jpeg"
+            )
+        )
+        self.assertFalse(
+            name_requirements(
+                "https://cdn.onepiecechapters.com.attacker.example/page.png"
+            )
+        )
+
+    def test_extracts_only_ordered_reader_images_from_tcb_chapter(self):
+        html = b"""
+            <img src="/files/h-logo.png">
+            <img class="fixed-ratio-content"
+                 src="https://cdn.onepiecechapters.com/file/page-01.png">
+            <img class="fixed-ratio-content other"
+                 src="https://cdn.onepiecechapters.com/file/page-02.jpg">
+            <img src="https://cdn.onepiecechapters.com/file/thumbnail.png">
+        """
+
+        self.assertEqual(
+            extract_chapter_image_urls(html, "tcbonepiecechapters.com"),
+            [
+                "https://cdn.onepiecechapters.com/file/page-01.png",
+                "https://cdn.onepiecechapters.com/file/page-02.jpg",
+            ],
+        )
 
     def test_scanner_includes_webp(self):
         with tempfile.TemporaryDirectory() as directory:

--- a/utils.py
+++ b/utils.py
@@ -11,15 +11,47 @@ import requests
 from bs4 import BeautifulSoup
 from skimage import io
 
-SUPPORTED_IMAGE_EXTENSIONS = {".png", ".webp"}
+OP_CHAPTER_HOSTS = {"opchapters.com", "www.opchapters.com"}
+TCB_CHAPTER_HOSTS = {
+    "tcbonepiecechapters.com",
+    "www.tcbonepiecechapters.com",
+}
+SUPPORTED_CHAPTER_HOSTS = OP_CHAPTER_HOSTS | TCB_CHAPTER_HOSTS
+OP_IMAGE_EXTENSIONS = {".png", ".webp"}
+TCB_IMAGE_HOSTS = {"cdn.onepiecechapters.com"}
+TCB_IMAGE_EXTENSIONS = {".jpg", ".jpeg", ".png", ".webp"}
 
 
 def name_requirements(src):
-    if not isinstance(src, str) or not src.startswith("https://i"):
+    if not isinstance(src, str):
         return False
 
-    extension = os.path.splitext(urlparse(src).path)[1].lower()
-    return extension in SUPPORTED_IMAGE_EXTENSIONS
+    parsed = urlparse(src)
+    if parsed.scheme != "https" or not parsed.hostname:
+        return False
+    extension = os.path.splitext(parsed.path)[1].lower()
+    if parsed.hostname.startswith("i"):
+        return extension in OP_IMAGE_EXTENSIONS
+    return (
+        parsed.hostname in TCB_IMAGE_HOSTS
+        and extension in TCB_IMAGE_EXTENSIONS
+    )
+
+
+def extract_chapter_image_urls(html, chapter_host):
+    soup = BeautifulSoup(html, "html.parser")
+    image_tags = soup.find_all("img")
+    if chapter_host in TCB_CHAPTER_HOSTS:
+        image_tags = [
+            image
+            for image in image_tags
+            if "fixed-ratio-content" in image.get("class", [])
+        ]
+    return [
+        image["src"]
+        for image in image_tags
+        if image.get("src") and name_requirements(image["src"])
+    ]
 
 REQUEST_TIMEOUT = (10, 60)
 MAX_IMAGE_BYTES = 25 * 1024 * 1024
@@ -31,19 +63,10 @@ def download_lmages(url, folder):
     response = requests.get(url, timeout=REQUEST_TIMEOUT)
     response.raise_for_status()
     final_host = urlparse(response.url).hostname
-    if final_host not in {"opchapters.com", "www.opchapters.com"}:
+    if final_host not in SUPPORTED_CHAPTER_HOSTS:
         raise ValueError("Chapter URL redirected to an unsupported host")
 
-    # Parse the HTML content using BeautifulSoup
-    soup = BeautifulSoup(response.content, "html.parser")
-    
-    # Find all the unage tags and extract the image URLS
-    img_tags = soup.find_all("img")
-    img_urls = [
-        img["src"]
-        for img in img_tags
-        if img.get("src") and name_requirements(img["src"])
-    ]
+    img_urls = extract_chapter_image_urls(response.content, final_host)
     if not img_urls:
         raise ValueError("No supported chapter images were found")
     if len(img_urls) > MAX_CHAPTER_IMAGES:


### PR DESCRIPTION
## What changed

- Allow HTTPS chapter URLs from `tcbonepiecechapters.com`.
- Extract ordered TCB reader pages from `cdn.onepiecechapters.com`.
- Support TCB JPG, JPEG, PNG, and WebP page images.
- Preserve strict chapter and image host checks, including redirect validation.
- Document the expanded source contract and add validation/extraction tests.

## Why

The frontend now accepts TCB links, but the API previously rejected the host and ignored TCB’s reader image markup.

## User impact

Readers can submit current TCB One Piece chapter URLs and process their pages through OnePanel.

## Validation

- `python -m pytest -q` (79 tests passed)
- `python -m compileall -q app.py utils.py`
- Live read-only check against TCB chapter 1189 found all 16 reader pages in order.